### PR TITLE
[BACK-377] Add Result Set Limiting

### DIFF
--- a/app/graphql/graphql.py
+++ b/app/graphql/graphql.py
@@ -1,4 +1,4 @@
-from graphene import ObjectType, String, Field, List, Schema
+from graphene import ObjectType, String, Field, List, Schema, Int
 
 from app.models.topic import TopicModel
 from app.models.topic_recommendations import TopicRecommendationsModel
@@ -7,13 +7,20 @@ from app.graphql.topic import Topic
 from app.graphql.topic_recommendations import TopicRecommendations
 
 
-
 class Query(ObjectType):
-    get_topic_recommendations = Field(TopicRecommendations, slug=String(required=True))
+    get_topic_recommendations = Field(TopicRecommendations, slug=String(required=True, description="Topic slug to get "
+                                                                                                   "recommendations "
+                                                                                                   "for"),
+                                      algorithmic_count=Int(default_value=30, description="Number of algorithmic "
+                                                                                          "results to return"),
+                                      curated_count=Int(default_value=30, description="Number of curated "
+                                                                                      "results to return"))
     list_topics = List(Topic)
 
-    def resolve_get_topic_recommendations(self, info, slug) -> TopicRecommendations:
-        return TopicRecommendationsModel.get_recommendations(slug=slug)
+    def resolve_get_topic_recommendations(self, info, slug: str, algorithmic_count: int,
+                                          curated_count: int) -> TopicRecommendations:
+        return TopicRecommendationsModel.get_recommendations(slug=slug, algorithmic_count=algorithmic_count,
+                                                             curated_count=curated_count)
 
     def resolve_list_topics(self, info) -> [TopicModel]:
         return TopicModel.get_all()

--- a/app/models/topic_recommendations.py
+++ b/app/models/topic_recommendations.py
@@ -8,11 +8,11 @@ class TopicRecommendationsModel(BaseModel):
     algorithmic_recommendations: List[RecommendationModel] = []
 
     @staticmethod
-    def get_recommendations(slug: str) -> ['TopicRecommendationsModel']:
+    def get_recommendations(slug: str, algorithmic_count: int, curated_count: int) -> ['TopicRecommendationsModel']:
         topic_recommendations = TopicRecommendationsModel()
         topic_recommendations.algorithmic_recommendations = RecommendationModel.get_recommendations(
             slug=slug,
-            recommendation_type=RecommendationType.ALGORITHMIC
+            recommendation_type=RecommendationType.ALGORITHMIC,
         )
         topic_recommendations.curated_recommendations = RecommendationModel.get_recommendations(
             slug=slug,
@@ -22,13 +22,18 @@ class TopicRecommendationsModel(BaseModel):
         # dedupe items in the algorithmic recommendations
         topic_recommendations = TopicRecommendationsModelUtils.dedupe(topic_recommendations)
 
+        # lets limit the result set to what was requested.
+        topic_recommendations = TopicRecommendationsModelUtils.limit_results(topic_recommendations,
+                                                                             algorithmic_count,
+                                                                             curated_count)
+
         # TODO: Publisher spread module
         return topic_recommendations
 
 
 class TopicRecommendationsModelUtils:
     @staticmethod
-    def dedupe(topic_recs_model: TopicRecommendationsModel) -> ['TopicRecommendationsModel']:
+    def dedupe(topic_recs_model: TopicRecommendationsModel) -> TopicRecommendationsModel:
         # are there dupes?
         curated_item_ids = {x.item_id for x in topic_recs_model.curated_recommendations}
         algorithmic_item_ids = {x.item_id for x in topic_recs_model.algorithmic_recommendations}
@@ -41,3 +46,16 @@ class TopicRecommendationsModelUtils:
                                                                   topic_recs_model.algorithmic_recommendations)
 
         return topic_recs_model
+
+    @staticmethod
+    def limit_results(topic_recommendations: TopicRecommendationsModel,
+                      algorithmic_count: int,
+                      curated_count: int
+                      ) -> TopicRecommendationsModel:
+        # The requester wants us to limit our results, so lets truncate the arrays
+        topic_recommendations.algorithmic_recommendations = topic_recommendations.algorithmic_recommendations[
+                                                            0: algorithmic_count]
+        topic_recommendations.curated_recommendations = topic_recommendations.curated_recommendations[
+                                                        0: curated_count]
+
+        return topic_recommendations

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,35 +1,35 @@
 type Query {
-  getTopicRecommendations(slug: String!): TopicRecommendations
-  listTopics: [Topic!]!
+    getTopicRecommendations(slug: String!, algorithmicCount: Int = 30, curatedCount: Int = 30): TopicRecommendations
+    listTopics: [Topic!]!
 }
 
 enum PageType {
-  editorial_collection
-  topic_page
+    editorial_collection
+    topic_page
 }
 
 type Topic {
- id: ID!
- displayName: String!
- displayNote: String
- slug: String!
- query: [String!]!
- curatorLabel: String!
- isDisplayed: Boolean!
- isPromoted: Boolean!
- socialTitle: String
- socialDescription: String
- socialImage: String
- pageType: PageType!
+    id: ID!
+    displayName: String!
+    displayNote: String
+    slug: String!
+    query: [String!]!
+    curatorLabel: String!
+    isDisplayed: Boolean!
+    isPromoted: Boolean!
+    socialTitle: String
+    socialDescription: String
+    socialImage: String
+    pageType: PageType!
 }
 
 type TopicRecommendations {
-  curatedRecommendations: [Recommendation!]!
-  algorithmicRecommendations: [Recommendation!]!
+    curatedRecommendations: [Recommendation!]!
+    algorithmicRecommendations: [Recommendation!]!
 }
 
 type Recommendation {
-  feedItemId: ID!
-  itemId: ID!
-  feedId: Int
+    feedItemId: ID!
+    itemId: ID!
+    feedId: Int
 }

--- a/tests/functional/graphql/test_topic_candidates_graphql.py
+++ b/tests/functional/graphql/test_topic_candidates_graphql.py
@@ -64,7 +64,10 @@ class TestGraphQLCandidates(TestDynamoDBBase):
             'data': {
                 'getTopicRecommendations': {
                     'algorithmicRecommendations': [],
-                    'curatedRecommendations': [{'feedItemId': 'ExploreTopics/123', 'feedId': 5, 'itemId': '123'},{'feedItemId': 'ExploreTopics/1253', 'feedId': None, 'itemId': '1253'}],
+                    'curatedRecommendations': [
+                        {'feedItemId': 'ExploreTopics/123', 'feedId': 5, 'itemId': '123'},
+                        {'feedItemId': 'ExploreTopics/1253', 'feedId': None, 'itemId': '1253'}
+                    ],
                 }
             }
         }

--- a/tests/unit/models/test_topic_recommendations_utils.py
+++ b/tests/unit/models/test_topic_recommendations_utils.py
@@ -61,3 +61,23 @@ class TestRecommendationsModelUtils:
         curated_result_ids = [res.item_id for res in result.curated_recommendations]
 
         assert curated_result_ids == [x.item_id for x in self.curated]
+
+    def test_limits_array(self):
+        algorithmic = TestRecommendationsModelUtils.generate_recommendations([1, 6, 7, 8, 9])
+        topic_recs = TopicRecommendationsModel()
+        topic_recs.curated_recommendations = self.curated
+        topic_recs.algorithmic_recommendations = algorithmic
+        result = TopicRecommendationsModelUtils.limit_results(topic_recs, curated_count=2, algorithmic_count=3)
+
+        assert len(result.algorithmic_recommendations) == 3
+        assert len(result.curated_recommendations) == 2
+
+    def test_limits_array_when_less(self):
+        algorithmic = TestRecommendationsModelUtils.generate_recommendations([1, 6, 7, 8, 9])
+        topic_recs = TopicRecommendationsModel()
+        topic_recs.curated_recommendations = self.curated
+        topic_recs.algorithmic_recommendations = algorithmic
+        result = TopicRecommendationsModelUtils.limit_results(topic_recs, curated_count=20, algorithmic_count=30)
+
+        assert len(result.algorithmic_recommendations) == 5
+        assert len(result.curated_recommendations) == 5


### PR DESCRIPTION
# Goal

Adds in result set limiting to the graphql api.


## Todos
- [x] Truncate arrays

## Review
- [ ] @Pocket/backend 

## Implementation Decisions

I chose to set the defaults to 30 results per item bucket. I also chose to just truncate the array after we de-dupe them.