### PR TITLE
Change namespace for production flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dmypy.json
 aws_lambda/*.zip
 aws_lambda/package
 aws_lambda/requirements.txt
+
+# misc
+/testing.py

--- a/aws_lambda/config/index.py
+++ b/aws_lambda/config/index.py
@@ -20,3 +20,10 @@ sentry = {
     'release': os.getenv('GIT_SHA', '1234'),
     'environment': os.getenv('ENVIRONMENT', 'local')
 }
+
+# 'runtime:step-functions' is a tag present only on production flow runs. This should be regarded as temporary!!!
+# We are going with this option because attempts to add a tag when the step function is created during code build
+# failed. An issue has been filed with metaflow's git repo: https://github.com/Netflix/metaflow/issues/384
+metaflow = {
+    'tag': os.getenv('METAFLOW_DEPLOY_TAG', 'runtime:step-functions')
+}

--- a/aws_lambda/index.py
+++ b/aws_lambda/index.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-from aws_lambda.config.index import sentry, secrets, dynamodb as dynamodb_config, topic_types
+from aws_lambda.config.index import sentry, secrets, dynamodb as dynamodb_config, topic_types, metaflow
 
 sentry_sdk.init(
     dsn=sentry.get('dsn'),
@@ -80,7 +80,7 @@ def get_metaflow_data(flow_name) -> List[Dict[str, Union[int, List[Dict[str, int
     namespace(get_tag())
     flow = Flow(flow_name)
     data = flow.latest_successful_run.data
-    return data.results
+    return data.final_results
 
 
 def get_service_url() -> str:
@@ -88,7 +88,7 @@ def get_service_url() -> str:
 
 
 def get_tag() -> str:
-    return get_json_key_secret_value(secret_id=secrets['metaflow'], json_key='METAFLOW_DEPLOY_TAG')
+    return metaflow.get('tag')
 
 
 # Because of https://github.com/aws/aws-secretsmanager-caching-python/pull/17 we can not use function decorators

--- a/tests/functional/aws_lambda/test_lambda.py
+++ b/tests/functional/aws_lambda/test_lambda.py
@@ -57,7 +57,7 @@ class TestLambda(TestDynamoDBBase):
         assert aws_lambda.index.get_service_url() == 'http://test'
 
     def test_get_tag(self, mocker):
-        assert aws_lambda.index.get_tag() == 'test'
+        assert aws_lambda.index.get_tag() == 'runtime:step-functions'
 
     def create_test_secret(self):
         self.secrets_manager.create_secret(


### PR DESCRIPTION
## Goal

Due to a bug in the metaflow cli, we currently cannot add tags to a Step Function's flow runs during code build.
Technically, we can add it and can verify that it's added in the Step Function's definition but it doesn't get applied to the runs.

@bassrock and I filed a github issue to hopefully get this fixed: https://github.com/Netflix/metaflow/issues/384

The workaround here is to use a tag that is generated and only present in Step Function flows