### PR TITLE
[BACK-369] Adding in collection responses

### DIFF
--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 
 class RecommendationType(Enum):
+    COLLECTION = 'collection'
     CURATED = 'curated'
     ALGORITHMIC = 'algorithmic'
 

--- a/tests/functional/graphql/test_topic_candidates_graphql.py
+++ b/tests/functional/graphql/test_topic_candidates_graphql.py
@@ -8,7 +8,6 @@ from app.config import dynamodb as dynamodb_config
 
 @mock_dynamodb2
 class TestGraphQLCandidates(TestDynamoDBBase):
-
     metadataTable: DynamoDBServiceResource.Table
     candidateTable: DynamoDBServiceResource.Table
     client: Client
@@ -25,7 +24,7 @@ class TestGraphQLCandidates(TestDynamoDBBase):
         self.metadataTable.delete()
         self.candidateTable.delete()
 
-    def test_main_get_topic_recommendations(self):
+    def test_get_topic_recommendations(self):
         self.metadataTable.put_item(Item={
             "id": "123123-12sd1asd3-5512",
             "display_name": 'tech',
@@ -69,6 +68,95 @@ class TestGraphQLCandidates(TestDynamoDBBase):
                     'curatedRecommendations': [
                         {'feedItemId': 'ExploreTopics/123', 'feedId': 5, 'itemId': '123', 'publisher': 'test.yes'},
                         {'feedItemId': 'ExploreTopics/1253', 'feedId': None, 'itemId': '1253', 'publisher': 'test.yes'}
+                    ],
+                }
+            }
+        }
+
+    def test_get_collection_topic_recommendations(self):
+        self.metadataTable.put_item(Item={
+            "id": "123123-12sd1asd3-5512",
+            "display_name": 'special',
+            "slug": 'special',
+            "query": 'query',
+            "curator_label": 'technology',
+            "page_type": 'editorial_collection',
+            "is_displayed": True,
+            "is_promoted": False
+        })
+
+        self.candidateTable.put_item(Item={
+            "id": "asdasd-12sd1asd3-5512",
+            "topic_id": '123123-12sd1asd3-5512',
+            "type": 'collection',
+            "topic_id-type": '123123-12sd1asd3-5512|collection',
+            "created_at": "2020-03-05T00:13:52.093Z",
+            "candidates": [
+                {
+                    'item_id': 123,
+                    'feed_id': 5,
+                    'publisher': 'special.yes'
+                },
+                {
+                    'item_id': 1253,
+                    'publisher': 'test.yes'
+                }
+            ]
+        })
+
+        self.candidateTable.put_item(Item={
+            "id": "a1dasd-12sd15d3-5522",
+            "topic_id": '123123-12sd1asd3-5512',
+            "type": 'algorithmic',
+            "topic_id-type": '123123-12sd1asd3-5512|algorithmic',
+            "created_at": "2020-03-05T00:13:52.093Z",
+            "candidates": [
+                {
+                    'item_id': 123123123123,
+                    'feed_id': 5,
+                    'publisher': 'special.yes'
+                },
+                {
+                    'item_id': 64556345,
+                    'publisher': 'test.yes'
+                }
+            ]
+        })
+
+        self.candidateTable.put_item(Item={
+            "id": "asdasd-12s2asd3-5312",
+            "topic_id": '123123-12sd1asd3-5512',
+            "type": 'curated',
+            "topic_id-type": '123123-12sd1asd3-5512|curated',
+            "created_at": "2020-03-05T00:13:52.093Z",
+            "candidates": [
+                {
+                    'item_id': 8675309,
+                    'feed_id': 5,
+                    'publisher': '1234.yes'
+                },
+                {
+                    'item_id': 8675309999999,
+                    'publisher': '1235.yes'
+                }
+            ]
+        })
+
+
+        executed = self.client.execute('''{
+            getTopicRecommendations(slug: "special") {
+                algorithmicRecommendations {feedItemId itemId feedId publisher}
+                curatedRecommendations {feedItemId itemId feedId publisher}
+            }
+        }''')
+        assert executed == {
+            'data': {
+                'getTopicRecommendations': {
+                    'algorithmicRecommendations': [],
+                    'curatedRecommendations': [
+                        {'feedItemId': 'ExploreTopics/123', 'feedId': 5, 'itemId': '123', 'publisher': 'special.yes'},
+                        {'feedItemId': 'ExploreTopics/1253', 'feedId': None, 'itemId': '1253',
+                         'publisher': 'test.yes'}
                     ],
                 }
             }


### PR DESCRIPTION
# Goal

Add in collection responses to the endpoint

https://getpocket.atlassian.net/browse/BACK-369


The current behavior of "collection" pages is to just fill up the curated response. So in this case we check if the page is a collection and if so we will only fill the curated response with "collection" results.