### PR TITLE
Add a longreads feed

### DIFF
--- a/jobs/LongReadsFlow.py
+++ b/jobs/LongReadsFlow.py
@@ -138,7 +138,7 @@ class LongReadsCandidatesFlow(FlowSpec):
 
         from elasticsearch_dsl import Search
         from elasticsearch.exceptions import NotFoundError, RequestError, AuthorizationException
-        from query import algorithmic_by_length, postprocess_search_results
+        from query import algorithmic_by_counts, postprocess_search_results
         from ranking import apply_rankers
 
         logger = logging.getLogger()
@@ -147,11 +147,11 @@ class LongReadsCandidatesFlow(FlowSpec):
         logger.info("Metaflow says its time to get longreads results")
         logger.info(f"min_saves: {self.input}, scale: {self.time_scale} \
                     filter_curated: {self.filter_curated}, approval_ranking: {self.approval_modeling}")
-        longreads_query, score_fuctions = algorithmic_by_length(min_saves=self.min_saves,
-                                                                scale=self.time_scale,
-                                                                min_words=self.min_words,
-                                                                save_origin=self.save_origin,
-                                                                save_scale=self.save_scale)
+        longreads_query, score_functions = algorithmic_by_counts(min_saves=self.min_saves,
+                                                                 scale=self.time_scale,
+                                                                 min_words=self.min_words,
+                                                                 save_origin=self.save_origin,
+                                                                 save_scale=self.save_scale)
 
         domain_allowlist = json.loads(self.domain_allowlist_file)
         logger.info(f"Metaflow says its time to get some elasticsearch results for long reads")
@@ -161,7 +161,7 @@ class LongReadsCandidatesFlow(FlowSpec):
             s = Search(using=self.es, index=self.es_path).query("function_score",
                                                                 query=longreads_query,
                                                                 min_score=0.01,
-                                                                functions=score_fuctions)
+                                                                functions=score_functions)
 
             # get extra results in case some are duplicates or filtered downstream
             total = min(900, self.limit*9)

--- a/jobs/Pipfile
+++ b/jobs/Pipfile
@@ -1,0 +1,23 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+pytest-cov = "*"
+coverage = "*"
+requests = "*"
+ipython = "*"
+pytest-mock = "*"
+
+[packages]
+metaflow = "*"
+elasticsearch = "==7.10.0"
+elasticsearch-dsl = "==7.3.0"
+sentry-sdk = "*"
+graphene-pydantic = "==0.1.0"
+gql = "*"
+
+[requires]
+python_version = "3.8"

--- a/jobs/Pipfile.lock
+++ b/jobs/Pipfile.lock
@@ -1,0 +1,544 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "04ede46fb3314cc9b48442a5a60ada17d765ce8e12b476f12ba6f4ba124fc6c6"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "aniso8601": {
+            "hashes": [
+                "sha256:513d2b6637b7853806ae79ffaca6f3e8754bdd547048f5ccc1420aec4b714f1e",
+                "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"
+            ],
+            "version": "==7.0.0"
+        },
+        "astroid": {
+            "hashes": [
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.3.3"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:ad0e8dbd934d97b5228252785c0236c3ee4d464c14138f568e371bf43c6ea584",
+                "sha256:ee86c26b3d457aa4d0256d0535d13107c32aa33bb5eb2a0b2dac9d81c3aca405"
+            ],
+            "version": "==1.16.37"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:5605c250f6f7c72ca50e45eab6186dfda03cb84296ca5b05f7416defcd3fcbc5",
+                "sha256:67bf1285455d79336ce7061da1768206b78f7a0efc13c8b4033fd348a74e7491"
+            ],
+            "version": "==1.19.37"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
+        "elasticsearch": {
+            "hashes": [
+                "sha256:9053ca99bc9db84f5d80e124a79a32dfa0f7079b2112b546a03241c0dbeda36d",
+                "sha256:9a21bfa7dc6a0b0dc142088bd653d8ce5ab284b4f7a3ded716185adf5276a7fe"
+            ],
+            "index": "pypi",
+            "version": "==7.10.0"
+        },
+        "elasticsearch-dsl": {
+            "hashes": [
+                "sha256:0ed75f6ff037e36b2397a8e92cae0ddde79b83adc70a154b8946064cb62f7301",
+                "sha256:9390d8e5cf82ebad3505e7f656e407259cf703f5a4035f211cef454127672572"
+            ],
+            "index": "pypi",
+            "version": "==7.3.0"
+        },
+        "gql": {
+            "hashes": [
+                "sha256:35032ddd4bfe6b8f3169f806b022168932385d751eacc5c5f7122e0b3f4d6b88",
+                "sha256:fe8d3a08047f77362ddfcfddba7cae377da2dd66f5e61c59820419c9283d4fb5"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "graphene": {
+            "hashes": [
+                "sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896",
+                "sha256:2cbe6d4ef15cfc7b7805e0760a0e5b80747161ce1b0f990dfdc0d2cf497c12f9"
+            ],
+            "version": "==2.1.8"
+        },
+        "graphene-pydantic": {
+            "hashes": [
+                "sha256:24a8184fb881ed7dc99578824b745b45565f87ee939dcee87bc77e01ec646ca0",
+                "sha256:723c81cd0427131e2e1a72fcde44dede63bc91bb7e8f5d37ddc5cbacdad6639e"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
+        },
+        "graphql-core": {
+            "hashes": [
+                "sha256:44c9bac4514e5e30c5a595fac8e3c76c1975cae14db215e8174c7fe995825bad",
+                "sha256:aac46a9ac524c9855910c14c48fc5d60474def7f99fd10245e76608eba7af746"
+            ],
+            "version": "==2.3.2"
+        },
+        "graphql-relay": {
+            "hashes": [
+                "sha256:870b6b5304123a38a0b215a79eace021acce5a466bf40cd39fa18cb8528afabb",
+                "sha256:ac514cb86db9a43014d7e73511d521137ac12cf0101b2eaa5f0a3da2e10d913d"
+            ],
+            "version": "==2.0.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.3.21"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.0"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4.3"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "metaflow": {
+            "hashes": [
+                "sha256:da5f59d8ceddb5054c19b8f1f39b36ddb8ab55ec9e824e769a5c9a3eb9d42ec1",
+                "sha256:f3965d22b86d2cbe431e3420024c21e37fa4106bc8b00f8b703266990768baf7"
+            ],
+            "index": "pypi",
+            "version": "==2.2.5"
+        },
+        "promise": {
+            "hashes": [
+                "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"
+            ],
+            "version": "==2.3"
+        },
+        "pydantic": {
+            "hashes": [
+                "sha256:1998e5f783c37853c6dfc1e6ba3a0cc486798b26920822b569ea883b38fd39eb",
+                "sha256:1ab625f56534edd1ecec5871e0777c9eee1c7b38f1963d97c4a78b09daf89526",
+                "sha256:1c97f90056c2811d58a6343f6352820c531e822941303a16ccebb77bbdcd4a98",
+                "sha256:2b49f9ecefcdee47f6b70fd475160eeda01c28507137d9c1ed41a758d231c060",
+                "sha256:390844ede21e29e762c0017e46b4105edee9dcdc0119ce1aa8ab6fe58448bd2f",
+                "sha256:4aa11a8a65fa891489d9e4e8f05299d80b000c554ce18b03bb1b5f0afe5b73f4",
+                "sha256:61e3cde8e7b8517615da5341e0b28cc01de507e7ac9174c3c0e95069482dcbeb",
+                "sha256:6ea91ec880de48699c4a01aa92ac8c3a71363bb6833bf031cb6aa2b99567d5ab",
+                "sha256:8154df22783601d9693712d1cee284c596cdb5d6817f57c1624bcb54e4611eba",
+                "sha256:82242b0458b0a5bad0c15c36d461b2bd99eec2d807c0c5263f802ba30cb856f0",
+                "sha256:a12e2fc2f5529b6aeb956f30a2b5efe46283b69e965888cd683cd1a04d75a1b8",
+                "sha256:aedd4df265600889907d2c74dc0432709b0ac91712f85f3ffa605b40a00f2577",
+                "sha256:b1c229e595b53d1397435fb7433c841c5bc4032ba81f901156124b9d077b5f6a",
+                "sha256:d88e55dc77241e2b78139dac33ad5edc3fd78b0c6e635824e4eeba6679371707",
+                "sha256:dd78ccb5cfe26ae6bc3d2a1b47b18a5267f88be43cb768aa6bea470c4ac17099",
+                "sha256:de093dcf6a8c6a2f92f8ac28b713b9f4ad80f1e664bdc9232ad06ac912c559fc",
+                "sha256:df5c511b8af11834b3061b33211e0aefb4fb8e2f94b939aa51d844cae22bad5c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.6"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
+                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.4.4"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.8.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.0"
+        },
+        "rx": {
+            "hashes": [
+                "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23",
+                "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"
+            ],
+            "version": "==1.6.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
+        "sentry-sdk": {
+            "hashes": [
+                "sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0",
+                "sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f"
+            ],
+            "index": "pypi",
+            "version": "==0.19.5"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.15.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.26.2"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+            ],
+            "version": "==1.11.2"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
+                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
+            ],
+            "version": "==0.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
+                "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
+                "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9",
+                "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097",
+                "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0",
+                "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f",
+                "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7",
+                "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c",
+                "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5",
+                "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7",
+                "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729",
+                "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978",
+                "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9",
+                "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f",
+                "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9",
+                "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822",
+                "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418",
+                "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82",
+                "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f",
+                "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d",
+                "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221",
+                "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4",
+                "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21",
+                "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709",
+                "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54",
+                "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d",
+                "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270",
+                "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24",
+                "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751",
+                "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a",
+                "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237",
+                "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7",
+                "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
+                "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
+            ],
+            "index": "pypi",
+            "version": "==5.3"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
+                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
+            ],
+            "version": "==4.4.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:c987e8178ced651532b3b1ff9965925bfd445c279239697052561a9ab806d28f",
+                "sha256:cbb2ef3d5961d44e6a963b9817d4ea4e1fa2eb589c371a470fed14d8d40cbd6a"
+            ],
+            "index": "pypi",
+            "version": "==7.19.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20",
+                "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.17.2"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.8"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea",
+                "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.7.1"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:25c95d2ac813909f813c93fde734b6e44406d1477a9faef7c915ff37d39c0a8c",
+                "sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.0.8"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716",
+                "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.7.3"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
+                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
+            ],
+            "index": "pypi",
+            "version": "==6.2.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
+                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:c0fc979afac4aaba545cbd01e9c20736eb3fefb0a066558764b07d3de8f04ed3",
+                "sha256:c3981f5edee6c4d1942250a60d9b39d38d5585398de1bfce057f925bdda720f4"
+            ],
+            "index": "pypi",
+            "version": "==3.4.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.2"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396",
+                "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.5"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.26.2"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+            ],
+            "version": "==0.2.5"
+        }
+    }
+}

--- a/jobs/TrendingCandidates.py
+++ b/jobs/TrendingCandidates.py
@@ -1,0 +1,142 @@
+import json
+import logging
+
+from metaflow import FlowSpec, step, Parameter, IncludeFile, conda, conda_base, schedule, Flow, namespace
+from utils import setup_logger
+
+
+@schedule(hourly=True)
+@conda_base(libraries={"elasticsearch": "7.1.0", "elasticsearch-dsl": "7.1.0",
+                       "requests-aws4auth": "1.0.1", "scikit-learn": "0.23.2",
+                       "scipy": "1.5.3", "gql": "2.0.0"})
+class TrendingCandidatesFlow(FlowSpec):
+
+    es_endpoint = Parameter("es_endpoint",
+                            help="elasticsearch endpoint",
+                            type=str,
+                            default="search-item-recs-wslncyus6txlpavliekv7bvrty.us-east-1.es.amazonaws.com")
+
+    es_path = Parameter("es_path",
+                        help="elasticsearch index",
+                        type=str,
+                        default="item-rec-data_v3")
+
+    limit = Parameter("limit",
+                      help="The number of items to recommend in the topic.",
+                      type=int,
+                      default=45)
+
+    min_saves = Parameter("min_saves",
+                          help="minimum required saves for recommendation filtering, default is 45",
+                          type=int,
+                          default=45)
+
+    time_scale = Parameter("time_scale",
+                           help="The time scale for the decay in elastic search, default is 6 days",
+                           type=str,
+                           default="12d")
+
+    save_origin = Parameter("save_origin",
+                            help="The origin for the save decay in elastic search, default is 600",
+                            type=int,
+                            default=600)
+
+    save_scale = Parameter("save_scale",
+                           help="The 0.5 scale for save decay for elastic search, default is 300",
+                           type=int,
+                           default=300)
+
+    approval_threshold = Parameter("approval_threshold",
+                                   help="The minimum percentile for approval probability, default is 30",
+                                   type=int,
+                                   default=30)
+
+    filter_curated = Parameter("filter_curated",
+                               help="Flag to filter of curated items from results.",
+                               type=bool,
+                               default=False)
+
+    approval_modeling = Parameter("approval_modeling",
+                                  help="Flag to rank items using curated approval model.",
+                                  type=bool,
+                                  default=True)
+
+    domain_allowlist_file = IncludeFile("domain_allowlist_file",
+                                        is_text=True,
+                                        help="Pocket domain allowlist",
+                                        default="./resources/domain_allowlist_20200630.json")
+
+    """
+    A flow where Metaflow generates trending candidates.
+    """
+    @step
+    def start(self):
+        """
+        This is the 'start' step. All flows must have a step named 'start' that
+        is the first step in the flow.
+        """
+        from utils import elasticsearch_connect
+
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+        logger.info("TrendingCandidatesFlow is starting.")
+        self.es = elasticsearch_connect(self.es_endpoint)
+
+        self.next(self.get_generic_approval_ranker)
+
+    @step
+    def get_generic_approval_ranker(self):
+        """
+        step to load models trained in ExploreTopicTrainingFlow
+        """
+
+        from utils import load_generic_approval_ranker
+        self.model_run_id, self.featurizer, self.approval_model = load_generic_approval_ranker()
+
+        self.next(self.get_results)
+
+    @step
+    def get_results(self):
+        """
+        A step for metaflow to issue a single topic query and get the results
+        from elastic search and apply model-based ranking
+        """
+        from utils import query_elasticsearch
+        from query import algorithmic_by_counts
+
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+
+        logger.info("Metaflow says its time to get trending results")
+        logger.info(f"min_saves: {self.input}, scale: {self.time_scale} \
+                    filter_curated: {self.filter_curated}, approval_ranking: {self.approval_modeling}")
+        trending_query, score_functions = algorithmic_by_counts(min_saves=self.min_saves,
+                                                                scale=self.time_scale,
+                                                                save_origin=self.save_origin,
+                                                                save_scale=self.save_scale)
+
+        domain_allowlist = json.loads(self.domain_allowlist_file)
+        logger.info(f"Metaflow says its time to get some elasticsearch results for trending")
+        logger.info(f"min_saves: {self.min_saves} scale: {self.time_scale} min_words: {self.min_words}")
+
+        search_results = query_elasticsearch(trending_query, score_functions, domain_allowlist,
+                                             self.es, self.es_path, None, self.approval_model,
+                                             self.featurizer, self.approval_threshold, self.limit)
+
+        self.final_results = [{"feed_name": "trending",
+                               "items": search_results}]
+        logger.info(f"Returned {len(search_results)} for trending")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+        """
+        pass
+
+
+if __name__ == '__main__':
+    setup_logger()
+    TrendingCandidatesFlow()

--- a/jobs/query.py
+++ b/jobs/query.py
@@ -240,7 +240,7 @@ def algorithmic_by_topic(curator_topic: str, topic_map: Dict, min_saves: int = 3
     return Bool(filter=bool_query, should=kw_query), score_functions
 
 
-def algorithmic_by_length(min_saves: int = 300, scale: str = None, min_words: int = 1200,
+def algorithmic_by_counts(min_saves: int = 300, scale: str = None, min_words: int = 200,
                           save_origin: int = 6000, save_scale: int = 3000):
     """
     routine to generate algorithmic elasticsearch query
@@ -279,8 +279,8 @@ def algorithmic_by_length(min_saves: int = 300, scale: str = None, min_words: in
                              ),
                        FieldValueFactor(field="impact_scores.total_score"),
                        Gauss(action_counts__open_count={
-                             "origin": save_origin,
-                             "scale": save_scale
+                             "origin": (save_origin // 2),
+                             "scale": (save_scale // 2)
                              }, weight=3),
                        Gauss(action_counts__save_count={
                                 "origin": save_origin,

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -1,5 +1,8 @@
 import logging
 import sys
+import os
+
+from metaflow import namespace, Flow
 
 
 def setup_logger():
@@ -30,7 +33,7 @@ def convert_to_days(scale: str) -> str:
     return scale2
 
 
-def _check_timescale(qstr: str, splitter: str = "w"):
+def _check_timescale(qstr: str, splitter: str = "w") -> bool:
     """
     this routine checks to see if timescale is in weeks
     :param qstr: the timescale string
@@ -39,3 +42,106 @@ def _check_timescale(qstr: str, splitter: str = "w"):
     """
     return qstr.partition(splitter)[0].isdigit() and qstr.partition(splitter)[1] == splitter
 
+
+def elasticsearch_connect(es_endpoint: str):
+    """
+    this routine establishes a connection to elasticsearch and returns the client
+    :param flowname: this is the name of the flow and is used for logging
+    :param es_endpoint: this is the URL for the elasticsearch cluster
+    :return: elasticsearch client for subsequent queries
+    """
+    # metaflow imports by step, thus they appear below
+    import boto3
+    from elasticsearch import Elasticsearch, RequestsHttpConnection
+    from requests_aws4auth import AWS4Auth
+
+    session = boto3.Session()
+    credentials = session.get_credentials()
+    region = os.environ.get('AWS_REGION', 'us-east-1')
+    awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, "es",
+                       session_token=credentials.token)
+    es = Elasticsearch(
+        hosts=[{'host': es_endpoint, 'port': 443}],
+        http_auth=awsauth,
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection
+    )
+
+    return es
+
+
+def load_generic_approval_ranker(model_training_flow: str = "ExploreTopicTrainingFlow"):
+    """
+    this routine loads the generic approval model trained in the ExploreTopicTrainingFlow
+    :param model_training_flow: this string identifies the flow that generated the desired model
+    :return: the run_id for the model, the featurizer, and the model
+
+    Here we need to change the namespace to the production one of the corresponding model we are looking to pull
+    Once https://github.com/Netflix/metaflow/issues/384 is merged and the topic model training has the right tags
+    added we will be able to change this to just "production" and pull it from AWS Secrets Manager
+    """
+    namespace("production:exploretopictrainingflow-0-eins")
+
+    training_run = Flow(model_training_flow).latest_successful_run
+    model_run_id = training_run.id
+    # get vectorizer, one hot mappings for google categories and domains
+    featurizer = training_run.data.featurizer
+
+    # get generic approval model
+    approval_model = training_run.data.generic_classifier
+
+    return model_run_id, featurizer, approval_model
+
+
+def query_elasticsearch(es_query, score_fcns, domain_allowlist, es_client, es_path,
+                        topic_predictor, approval_model, featurizer, approval_threshold,
+                        limit, min_score=0.01):
+    """
+    this routine issues function score queries to elasticsearch
+    :param es_query:
+    :param score_fcns:
+    :param domain_allowlist:
+    :param es_client:
+    :param es_path:
+    :param topic_predictor:
+    :param approval_model:
+    :param featurizer:
+    :param approval_threshold:
+    :param limit:
+    :param min_score:
+    :return:
+    """
+
+    from elasticsearch_dsl import Search
+    from elasticsearch.exceptions import NotFoundError, RequestError, AuthorizationException
+    from query import postprocess_search_results
+    from ranking import apply_rankers
+
+    logger = logging.getLogger()
+    try:
+        s = Search(using=es_client, index=es_path).query("function_score",
+                                                         query=es_query,
+                                                         min_score=min_score,
+                                                         functions=score_fcns)
+
+        # get extra results in case some are duplicates or filtered downstream
+        total = min(900, limit * 9)
+        s = s[:total]
+        search_results = postprocess_search_results(s.execute().to_dict(),
+                                                         domain_allowlist,
+                                                         limit * 6)
+
+    except (NotFoundError, RequestError, AuthorizationException) as err:
+        logger.error("ElasticSearch " + str(err))
+        sys.exit(1)
+
+    logger.info("Metaflow says its time to get apply ranking models to elasticsearch results")
+    results = apply_rankers(search_results,
+                            topic_predictor=topic_predictor,
+                            approval_model=approval_model,
+                            count=limit,
+                            featurizer=featurizer,
+                            approval_percentile=approval_threshold)
+
+    return results


### PR DESCRIPTION
# Goal

Adding a long reads feed metaflow candidate generation script to the recommendations api

## Todos
- [ ] editorial QA
- [x] Make preview [notebook](https://github.com/Pocket/metaflow-notebooks/blob/main/LongReads%20Candidates.ipynb)
- [x] Test in shell with batch

## Implementation Decisions

* minimum word count cutoff is 4500 = 225 WPM * 20 mins
* minimum save cutoff is 45
* using generic approval ranker to filter low approval probability items
* elastic search function score query ranks using Gaussian decay to combine
    - total opens
    - total saves
    - time since time_first_parsed
    - total score

