### PR TITLE
[SHIPIT-21] lock python to version 3.8.5

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -98,6 +98,9 @@ phases:
       - source "$HOME/miniconda/etc/profile.d/conda.sh"
       - hash -r
       - conda config --append channels conda-forge
+
+      # Install python for conda. We need to do this to make sure the python version
+      # pipenv uses to run the flows are conda compatible
       - conda install python=3.8
 
       # Install deployment packages from jobs/Pipfile.lock so we can run metaflow


### PR DESCRIPTION
# Goal

Install python for conda during build

Jira Ticket: BACK-566