### PR TITLE
[back-577] add experiment id generation when parsing json

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from xraysink.context import AsyncContext
 from app.config import ENV, ENV_PROD, service, sentry as sentry_config
 from app.graphql.graphql import schema
 from app.graphql_app import GraphQLAppWithMiddleware, GraphQLSentryMiddleware
-from app.models.experiment import Experiment
+from app.models.experiment import ExperimentModel
 from app.models.slateconfig import SlateConfigModel
 
 
@@ -57,7 +57,7 @@ async def load_slate_configs():
                 for cs in experiment.candidate_sets:
                     # TODO: this check is currently stubbed to return True
                     # https://getpocket.atlassian.net/browse/BACK-598 will implement
-                    if not Experiment.candidate_set_is_valid(cs):
+                    if not ExperimentModel.candidate_set_is_valid(cs):
                         raise ValueError(f'{slateconfig.id}|{experiment.description}|{cs} was not found in the database - '
                                          'application start failed')
 

--- a/app/models/experiment.py
+++ b/app/models/experiment.py
@@ -1,13 +1,17 @@
+import hashlib
+import json
+
 from typing import List
 
 from app.rankers.rankers import RANKERS as ALL_RANKERS
 
 
-class Experiment:
+class ExperimentModel:
     # should this be in a config somewhere?
     DEFAULT_WEIGHT = 1
 
-    def __init__(self, description: str, candidate_sets: List[str], rankers: List[str], weight: float = DEFAULT_WEIGHT):
+    def __init__(self, experiment_id: str, description: str, candidate_sets: List[str], rankers: List[str],
+                 weight: float = DEFAULT_WEIGHT):
         # initialize values
         self.rankers = []
 
@@ -30,20 +34,40 @@ class Experiment:
 
                 self.rankers.append(ranker)
 
+        self.id = experiment_id
         self.description = description
         self.candidate_sets = candidate_sets
         self.weight = weight
 
     @staticmethod
-    def load_from_dict(experiment_dict: dict) -> 'Experiment':
+    def generate_experiment_id(experiment_dict: dict) -> str:
+        """
+        Generates an ID for an experiment based on the dictionary representation of the experiment. This will ensure that
+        if an experiment changes, the ID will also change (which helps analytics).
+        :param experiment_dict: dictionary representation of an experiment (after parsing from json)
+        :return: first 7 characters of the hash created
+        """
+        hashed = hashlib.sha1(
+            json.dumps(experiment_dict, sort_keys=True).encode()
+        ).hexdigest()
+
+        return hashed[:7]
+
+    @staticmethod
+    def load_from_dict(experiment_dict: dict) -> 'ExperimentModel':
         """
         creates an experiment object from a json-derived dictionary
         :param experiment_dict: a dictionary derived from parsing json
         :return: an instance of Experiment
         """
-        weight = experiment_dict.get('weight', Experiment.DEFAULT_WEIGHT)
-        return Experiment(experiment_dict["description"], experiment_dict["candidateSets"], experiment_dict["rankers"],
-                          weight)
+        # generate an id for the experiment
+        experiment_id = ExperimentModel.generate_experiment_id(experiment_dict)
+
+        # determine the weight
+        weight = experiment_dict.get('weight', ExperimentModel.DEFAULT_WEIGHT)
+
+        return ExperimentModel(experiment_id, experiment_dict["description"], experiment_dict["candidateSets"],
+                               experiment_dict["rankers"], weight)
 
     @staticmethod
     def candidate_set_is_valid(candidate_set: str) -> bool:

--- a/app/models/slateconfig.py
+++ b/app/models/slateconfig.py
@@ -4,7 +4,7 @@ from typing import List
 
 from app.config import JSON_DIR
 from app.json.utils import parse_to_dict
-from app.models.experiment import Experiment
+from app.models.experiment import ExperimentModel
 
 # store loaded slates
 SLATE_CONFIGS = []
@@ -64,7 +64,7 @@ class SlateConfigModel:
 
             # populate experiments for the slate
             for ex in s["experiments"]:
-                slate.experiments.append(Experiment.load_from_dict(ex))
+                slate.experiments.append(ExperimentModel.load_from_dict(ex))
 
             slates_objs.append(slate)
 

--- a/tests/unit/models/test_experiment_model.py
+++ b/tests/unit/models/test_experiment_model.py
@@ -1,47 +1,51 @@
 import json
 import unittest
 
-from app.models.experiment import Experiment
+from app.models.experiment import ExperimentModel
 
 
-class TestExperimentInstantiation(unittest.TestCase):
+class TestExperimentModel(unittest.TestCase):
+    # test instantiation
+
     def test_no_weight(self):
-        ex = Experiment(description='d', candidate_sets=['a'], rankers=['top15'])
-        self.assertEqual(ex.weight, Experiment.DEFAULT_WEIGHT)
+        ex = ExperimentModel(experiment_id='c3h5n3o9', description='d', candidate_sets=['a'], rankers=['top15'])
+        self.assertEqual(ex.weight, ExperimentModel.DEFAULT_WEIGHT)
 
     def test_no_candidate_sets(self):
         with self.assertRaises(ValueError) as context:
-            Experiment(description='desc', candidate_sets=[], rankers=[], weight=0)
+            ExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=[], rankers=[], weight=0)
 
         self.assertTrue('no candidate sets provided for experiment' in str(context.exception))
 
     def test_no_rankers(self):
         with self.assertRaises(ValueError) as context:
-            Experiment(description='desc', candidate_sets=['a', 'b'], rankers=[], weight=0)
+            ExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'], rankers=[], weight=0)
 
         self.assertTrue('no rankers provided for experiment' in str(context.exception))
 
     def test_invalid_ranker(self):
         with self.assertRaises(KeyError) as context:
-            Experiment(description='desc', candidate_sets=['a', 'b'], rankers=['invalid'], weight=0)
+            ExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'], rankers=['invalid'], weight=0)
 
         self.assertTrue('invalid is not a valid ranker' in str(context.exception))
 
     def test_valid_instantiation(self):
+        ex_id = 'c3h5n3o9'
         desc = 'd'
         cs = ['a', 'b']
         rs = ['top15', 'pubspread']
         w = 0.2
 
-        experiment = Experiment(description=desc, candidate_sets=cs, rankers=rs, weight=w)
+        experiment = ExperimentModel(experiment_id=ex_id, description=desc, candidate_sets=cs, rankers=rs, weight=w)
 
+        self.assertEqual(experiment.id, ex_id)
         self.assertEqual(experiment.description, desc)
         self.assertEqual(experiment.candidate_sets, cs)
-        self.assertEqual(experiment.rankers, ['top15', 'pubspread'])
+        self.assertEqual(experiment.rankers, rs)
         self.assertEqual(experiment.weight, w)
 
+    # test loading from json
 
-class TestLoadFromJson(unittest.TestCase):
     def test_load_from_json_without_weight(self):
         json_str = """
             {
@@ -57,10 +61,10 @@ class TestLoadFromJson(unittest.TestCase):
            ]
          }
         """
-        ex = Experiment.load_from_dict(json.loads(json_str))
+        ex = ExperimentModel.load_from_dict(json.loads(json_str))
 
         self.assertEqual(ex.description, "TS window 30")
-        self.assertEqual(ex.weight, Experiment.DEFAULT_WEIGHT)
+        self.assertEqual(ex.weight, ExperimentModel.DEFAULT_WEIGHT)
         self.assertEqual(len(ex.candidate_sets), 2)
         self.assertEqual(len(ex.rankers), 3)
 
@@ -80,9 +84,34 @@ class TestLoadFromJson(unittest.TestCase):
            "weight": 0.3
          }
         """
-        ex = Experiment.load_from_dict(json.loads(json_str))
+        ex = ExperimentModel.load_from_dict(json.loads(json_str))
 
         self.assertEqual(ex.description, "TS window 15")
         self.assertEqual(ex.weight, 0.3)
         self.assertEqual(len(ex.candidate_sets), 3)
         self.assertEqual(len(ex.rankers), 2)
+
+    # test generating ids
+
+    def test_generate_experiment_id(self):
+        ex_dict = {
+            "description": "TS window 30",
+            "candidateSets": [
+                "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
+                "df8a86c1-8b40-48bf-b85d-c144ed96c3fc"
+            ],
+            "rankers": [
+                "top30",
+                "thompson-sampling",
+                "pubspread"
+            ]
+        }
+
+        ex_id = ExperimentModel.generate_experiment_id(ex_dict)
+        ex_id_again = ExperimentModel.generate_experiment_id(ex_dict)
+
+        # make sure we are only getting 7 characters
+        self.assertEqual(7, len(ex_id))
+
+        # make sure repeated calls with the same dict result in the same id
+        self.assertEqual(ex_id, ex_id_again)


### PR DESCRIPTION
# Goal

add experiment id generation when parsing slate/experiment json.

## Implementation Decisions

didn't catch this requirement in the initial PR. also renamed `Experiment` to `ExperimentModel` for consistency.