### PR TITLE
[back-611] allow empty/no rankers in layout & slate configs

### DIFF
--- a/app/models/experiment.py
+++ b/app/models/experiment.py
@@ -21,20 +21,16 @@ class ExperimentModel(metaclass=ABCMeta):
         # initialize values
         self.rankers = []
 
-        # validate rankers
-        if len(rankers) < 1:
-            raise ValueError('no rankers provided for experiment')
-        else:
-            for ranker in rankers:
-                # the ranker must exist in our pre-defined global list
-                if ranker not in ALL_RANKERS:
-                    raise KeyError(f'{ranker} is not a valid ranker')
+        for ranker in rankers:
+            # the ranker must exist in our pre-defined global list
+            if ranker not in ALL_RANKERS:
+                raise KeyError(f'{ranker} is not a valid ranker')
 
-                # the ranker cannot be duplicated in a single experiment
-                if ranker in self.rankers:
-                    raise KeyError(f'{ranker} was previously included in this list')
+            # the ranker cannot be duplicated in a single experiment
+            if ranker in self.rankers:
+                raise KeyError(f'{ranker} was previously included in this list')
 
-                self.rankers.append(ranker)
+            self.rankers.append(ranker)
 
         self.id = experiment_id
         self.description = description

--- a/tests/assets/json/layout_configs.json
+++ b/tests/assets/json/layout_configs.json
@@ -31,10 +31,7 @@
    "experiments": [
      {
        "description": "iOS is where it's at",
-       "rankers": [
-         "pubspread",
-         "top15"
-       ],
+       "rankers": [],
        "slates": [
          "d410516f-18b3-46a1-b356-c7c003de2b53"
        ]

--- a/tests/assets/json/slate_configs.json
+++ b/tests/assets/json/slate_configs.json
@@ -10,11 +10,7 @@
          "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
          "df8a86c1-8b40-48bf-b85d-c144ed96c3fc"
        ],
-       "rankers": [
-         "top30",
-         "thompson-sampling",
-         "pubspread"
-       ]
+       "rankers": []
      },
      {
        "description": "TS window 15",

--- a/tests/functional/models/test_layout_config_model.py
+++ b/tests/functional/models/test_layout_config_model.py
@@ -7,12 +7,12 @@ from app.config import ROOT_DIR
 
 class TestLayoutConfigModel(unittest.TestCase):
     def test_load_valid_slates(self):
-        layoutconfigs = LayoutConfigModel.load_layout_configs(os.path.join(ROOT_DIR, 'tests/assets/json/layout_configs.json'))
+        layout_configs = LayoutConfigModel.load_layout_configs(os.path.join(ROOT_DIR, 'tests/assets/json/layout_configs.json'))
 
         # make sure both layouts in the test file were loaded
-        self.assertEqual(3, len(layoutconfigs))
+        self.assertEqual(3, len(layout_configs))
 
         # make sure each layout's experiments were also loaded
         # (this is some wild list comprehension syntax - gets all experiments in all layouts)
-        experiments = [ex for lc in layoutconfigs for ex in lc.experiments]
+        experiments = [ex for lc in layout_configs for ex in lc.experiments]
         self.assertEqual(4, len(experiments))

--- a/tests/functional/models/test_slate_config_model.py
+++ b/tests/functional/models/test_slate_config_model.py
@@ -7,12 +7,12 @@ from app.config import ROOT_DIR
 
 class TestSlateConfigModel(unittest.TestCase):
     def test_load_valid_slates(self):
-        slateconfigs = SlateConfigModel.load_slate_configs(os.path.join(ROOT_DIR, 'tests/assets/json/slate_configs.json'))
+        slate_configs = SlateConfigModel.load_slate_configs(os.path.join(ROOT_DIR, 'tests/assets/json/slate_configs.json'))
 
         # make sure both slates in the test file were loaded
-        self.assertEqual(2, len(slateconfigs))
+        self.assertEqual(2, len(slate_configs))
 
         # make sure each slate's experiments were also loaded
         # (this is some wild list comprehension syntax - gets all experiments in all slates)
-        experiments = [ex for s in slateconfigs for ex in s.experiments]
+        experiments = [ex for s in slate_configs for ex in s.experiments]
         self.assertEqual(4, len(experiments))

--- a/tests/unit/models/test_layout_experiment_model.py
+++ b/tests/unit/models/test_layout_experiment_model.py
@@ -18,11 +18,10 @@ class TestLayoutExperimentModel(unittest.TestCase):
         self.assertTrue('no slates provided for experiment' in str(context.exception))
 
     def test_no_rankers(self):
-        with self.assertRaises(ValueError) as context:
-            LayoutExperimentModel(experiment_id='c3h5n3o9', description='desc', slates=['a', 'b'], rankers=[],
-                            weight=0)
+        lem = LayoutExperimentModel(experiment_id='c3h5n3o9', description='desc', slates=['a', 'b'], rankers=[],
+                                    weight=0)
 
-        self.assertTrue('no rankers provided for experiment' in str(context.exception))
+        self.assertEqual(len(lem.rankers), 0)
 
     def test_invalid_ranker(self):
         with self.assertRaises(KeyError) as context:

--- a/tests/unit/models/test_slate_experiment_model.py
+++ b/tests/unit/models/test_slate_experiment_model.py
@@ -18,11 +18,10 @@ class TestSlateExperimentModel(unittest.TestCase):
         self.assertTrue('no candidate sets provided for experiment' in str(context.exception))
 
     def test_no_rankers(self):
-        with self.assertRaises(ValueError) as context:
-            SlateExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'], rankers=[],
-                                 weight=0)
+        sem = SlateExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'], rankers=[],
+                                   weight=0)
 
-        self.assertTrue('no rankers provided for experiment' in str(context.exception))
+        self.assertEqual(len(sem.rankers), 0)
 
     def test_invalid_ranker(self):
         with self.assertRaises(KeyError) as context:
@@ -79,10 +78,7 @@ class TestSlateExperimentModel(unittest.TestCase):
                  "df8a86c1-8b40-48bf-b85d-c144ed96c3fc",
                  "df8a86c1-8b40-48bf-b85d-c144ed96c3fd"
                ],
-               "rankers": [
-                 "top15",
-                 "thompson-sampling"
-               ],
+               "rankers": [],
                "weight": 0.3
              }
             """
@@ -91,4 +87,4 @@ class TestSlateExperimentModel(unittest.TestCase):
         self.assertEqual(ex.description, "TS window 15")
         self.assertEqual(ex.weight, 0.3)
         self.assertEqual(len(ex.candidate_sets), 3)
-        self.assertEqual(len(ex.rankers), 2)
+        self.assertEqual(len(ex.rankers), 0)


### PR DESCRIPTION
# Goal

allows empty/no rankers for layout and slate configs.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-611
