### PR TITLE
[BACK-645] Log Sentry event when candidate set is missing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -86,9 +86,9 @@ async def load_slate_configs():
                     if not await CandidateSetModel.verify_candidate_set(cs):
                         # Send event to Sentry, but don't raise it, because missing candidate sets should not
                         # block successfully starting the application.
-                        e = MissingCandidateSetException(
-                            f'candidate set {slate_config.id}|{experiment.description}|{cs} was not found.')
-                        sentry_sdk.capture_exception(e)
+                        message = f'candidate set {slate_config.id}|{experiment.description}|{cs} was not found.'
+                        logging.error(message)
+                        sentry_sdk.capture_exception(MissingCandidateSetException(message))
 
         for layout_config in layout_configs:
             for experiment in layout_config.experiments:


### PR DESCRIPTION
# Goal
Log a Sentry event when Candidate Sets are missing on app startup. It should not prevent the application from starting up.

The error log we implemented for this before seems not to arrive at Sentry, which arguably is a bug as well.

![Screenshot from 2021-02-22 14-20-11](https://user-images.githubusercontent.com/1547251/108777783-32180800-7519-11eb-91a7-3ecd728e9cd9.png)

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-645

## Implementation Decisions
- If folks would rather raise an exception than directly sending it to Sentry, that works for me, too. The advantage of sending it directly to Sentry is that all missing candidate sets will be logged, instead of just the first one.
