### PR TITLE
add ecs plugin to xray

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,7 +32,7 @@ sentry_sdk.init(
 sentry_sdk.integrations.logging.ignore_logger("graphql.execution.utils")
 
 # Standard asyncio X-Ray configuration, customise as you choose
-xray_recorder.configure(context=AsyncContext(), service=service.get('domain'), plugins=('ECSPlugin'))
+xray_recorder.configure(context=AsyncContext(), service=service.get('domain'), plugins=['ecsplugin'])
 
 app = FastAPI()
 app.add_middleware(BaseHTTPMiddleware, dispatch=xray_middleware)


### PR DESCRIPTION
# Goal

XRay supports default plugins that adjust how it is shown in the AWS Console.

This enables the ECS plugin so xray knows that the data came from an ECS instance. It will then add a bit more ecs specific data to the trace.

## Todos
- [x] Add ecs plugin

## Review
- [ ] @Pocket/backend 

