### PR TITLE
[SHIPIT-123] Remove internal Confluence link from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 We use this app for serving customers recommendations of topics they might like.
 
-[Pocket only] See the [Service Directory](https://getpocket.atlassian.net/wiki/spaces/PE/pages/1626177549/RecommendationAPI)
-for information on contacts, architecture, and usage.
-
 ## Development Setup & Running Tests
 
 For complete instructions, see [docs/development.md](/docs/development.md).


### PR DESCRIPTION
# Goal
Avoid confusion in ReadMe, by removing a Confluence link that is not accessible publicly.