### PR TITLE
Check that GUIDs are unique

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ from app.graphql.user_middleware import UserMiddleware
 from app.graphql_app import GraphQLAppWithMiddleware, GraphQLSentryMiddleware
 from app.models.candidate_set import CandidateSetModel
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
-from app.models.slate_lineup_config import SlateLineupConfigModel
+from app.models.slate_lineup_config import SlateLineupConfigModel, validate_unique_guids
 from app.models.slate_config import SlateConfigModel
 from app.health_status import get_health_status, set_health_status, HealthStatus
 
@@ -85,6 +85,9 @@ async def load_slate_configs():
     SlateConfigModel.SLATE_CONFIGS_BY_ID = {s.id: s for s in slate_configs}
     slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
     SlateLineupConfigModel.SLATE_LINEUP_CONFIGS_BY_ID = {lc.id: lc for lc in slate_lineup_configs}
+
+    # Check for GUID re-use
+    validate_unique_guids(slate_lineup_configs, slate_configs)
 
     # Validate slate_lineup and slate configs on prod and dev, not locally.
     if ENV in {ENV_PROD, ENV_DEV}:

--- a/app/models/slate_config.py
+++ b/app/models/slate_config.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import os
 
 from typing import List
@@ -39,6 +40,7 @@ class SlateConfigModel:
         """
         return SlateConfigModel(slate_dict["id"], slate_dict["displayName"], slate_dict["description"])
 
+
     @staticmethod
     def load_slate_configs(
             slate_file=os.path.join(JSON_DIR, 'slate_configs.json'),
@@ -68,6 +70,8 @@ class SlateConfigModel:
 
             slates_objs.append(slate)
 
+        validate_slate_config(slates_objs)
+
         return slates_objs
 
     @staticmethod
@@ -84,3 +88,13 @@ class SlateConfigModel:
             raise ValueError(f'slate id {slate_id} was not found in the slate configs')
 
         return slate_config
+
+
+def validate_slate_config(slate_configs: List[SlateConfigModel]) -> None:
+    """
+    Validates that a GUID is not re-used in a slate config. Raises a `ValueError` if it is.
+    """
+    slate_ids = Counter([r.id for r in slate_configs])
+    dupes = [guid for guid, count in slate_ids.items() if count > 1]
+    if dupes:
+        raise ValueError(f"Slate GUIDs appears more than once in slate config: {dupes}")

--- a/app/models/slate_lineup_config.py
+++ b/app/models/slate_lineup_config.py
@@ -1,5 +1,5 @@
+from collections import Counter
 import os
-import random
 
 from typing import List
 
@@ -68,6 +68,8 @@ class SlateLineupConfigModel:
 
             slate_lineups_objs.append(slate_lineup)
 
+        validate_lineup_config(slate_lineups_objs)
+
         return slate_lineups_objs
 
     @staticmethod
@@ -116,3 +118,24 @@ class SlateLineupConfigModel:
             slate_configs = get_ranker(ranker)(slate_configs)
 
         return slate_configs
+
+
+def validate_lineup_config(lineup_configs: List[SlateLineupConfigModel]) -> None:
+    """
+    Validates that a GUID is not re-used in a slate config. Raises a `ValueError` if it is.
+    """
+    slate_ids = Counter([r.id for r in lineup_configs])
+    dupes = [guid for guid, count in slate_ids.items() if count > 1]
+    if dupes:
+        raise ValueError(f"Slate GUIDs appears more than once in slate config: {dupes}")
+
+
+def validate_unique_guids(lineup_configs: List[SlateLineupConfigModel], slate_configs: List[SlateConfigModel]) -> None:
+    """
+    Validate that GUIDs are unique across lineups and slates. Raises a `ValueError` if they are not.
+    """
+    lineup_guids = {r.id for r in lineup_configs}
+    slate_guids = {r.id for r in slate_configs}
+    guid_overlap = lineup_guids.intersection(slate_guids)
+    if guid_overlap:
+        raise ValueError(f"Lineup and Slates share GUIDS: {guid_overlap}")

--- a/tests/assets/json/invalid_slate_configs.json
+++ b/tests/assets/json/invalid_slate_configs.json
@@ -1,0 +1,59 @@
+[
+  {
+   "id": "c410516f-18b3-46a1-b356-c7c003de2b53",
+   "displayName": "Trending Articles",
+   "description": "Curated articles within the last week that have high cascade probability",
+   "experiments": [
+     {
+       "description": "TS window 30",
+       "candidateSets": [
+         "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
+         "df8a86c1-8b40-48bf-b85d-c144ed96c3fc"
+       ],
+       "rankers": []
+     },
+     {
+       "description": "TS window 15",
+       "candidateSets": [
+         "40d0dc54-f6f8-4f13-bea4-4320b3bd8218",
+         "ab8a86c1-8b40-48bf-b85d-c144ed96c3fd"
+       ],
+       "rankers": [
+         "top15",
+         "thompson-sampling",
+         "pubspread"
+       ],
+       "weight": 0.5
+     }
+   ]
+ },
+ {
+   "id": "c410516f-18b3-46a1-b356-c7c003de2b53",
+   "displayName": "Bending Particles",
+   "description": "Bended particles within the last week that have high dawn probability",
+   "experiments": [
+     {
+       "description": "TS window 15",
+       "candidateSets": [
+         "41d0dc54-f6f8-4f13-bea4-4320b3bd8219",
+         "cd8a86c1-8b40-48bf-b85d-c144ed96c3fe"
+       ],
+       "rankers": [
+         "thompson-sampling",
+         "top15"
+       ],
+       "weight": 0.2
+     },
+     {
+       "description": "PubSpread Candidates",
+       "candidateSets": [
+         "42d0dc54-f6f8-4f13-bea4-4320b3bd8220",
+         "ef8a86c1-8b40-48bf-b85d-c144ed96c3ff"
+       ],
+       "rankers": [
+         "pubspread"
+       ]
+     }
+   ]
+ }
+]

--- a/tests/assets/json/invalid_slate_lineup_configs.json
+++ b/tests/assets/json/invalid_slate_lineup_configs.json
@@ -26,7 +26,7 @@
    ]
  },
   {
-   "id": "34a35300-63c0-4ecc-8f11-4779b7dc1379",
+   "id": "34a35300-73c0-4ecc-8f11-4779b7dc1379",
    "description": "iOS discover",
    "experiments": [
      {
@@ -39,7 +39,7 @@
    ]
  },
   {
-   "id": "34a35300-53c0-4ecc-8f11-4779b7dc1379",
+   "id": "34a35300-73c0-4ecc-8f11-4779b7dc1379",
    "description": "firefoxOS discover",
    "experiments": [
      {

--- a/tests/functional/json/slate_lineup_config.py
+++ b/tests/functional/json/slate_lineup_config.py
@@ -1,15 +1,27 @@
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
 from app.models.slate_config import SlateConfigModel
-from app.models.slate_lineup_config import SlateLineupConfigModel
+from app.models.slate_lineup_config import SlateLineupConfigModel, validate_unique_guids
+import pytest
+
+
+def test_validate_config():
+    # Overlapping GUIDs between configs
+    slate_config = [SlateConfigModel("617d9613-d338-4cc0-92ba-9a90831f6a46", "dupe slate", "dupe slate")]
+    lineup_config = [SlateLineupConfigModel("617d9613-d338-4cc0-92ba-9a90831f6a46", "Duplicated GUID")]
+    with pytest.raises(ValueError):
+        validate_unique_guids(lineup_config, slate_config)
 
 
 def test_slate_lineup_config():
     """
-    Test that all slates referenced in the slate_lineup config exist.
+    Test that slate and lineup configs are valid
     """
     SlateConfigModel.SLATE_CONFIGS_BY_ID = {s.id: s for s in SlateConfigModel.load_slate_configs()}
     SlateLineupConfigModel.SLATE_LINEUP_CONFIGS = SlateLineupConfigModel.load_slate_lineup_configs()
 
+    validate_unique_guids(SlateLineupConfigModel.SLATE_LINEUP_CONFIGS, list(SlateConfigModel.SLATE_CONFIGS_BY_ID.items()))
+
+    # Check that referenced slates exist
     for slate_lineup_config in SlateLineupConfigModel.SLATE_LINEUP_CONFIGS:
         for experiment in slate_lineup_config.experiments:
             for slate in experiment.slates:

--- a/tests/functional/models/test_slate_config_model.py
+++ b/tests/functional/models/test_slate_config_model.py
@@ -16,3 +16,7 @@ class TestSlateConfigModel(unittest.TestCase):
         # (this is some wild list comprehension syntax - gets all experiments in all slates)
         experiments = [ex for s in slate_configs for ex in s.experiments]
         self.assertEqual(4, len(experiments))
+
+    def test_load_invalid_slate(self):
+        with self.assertRaises(ValueError):
+            SlateConfigModel.load_slate_configs(os.path.join(ROOT_DIR, 'tests/assets/json/invalid_slate_configs.json'))

--- a/tests/functional/models/test_slate_lineup_config_model.py
+++ b/tests/functional/models/test_slate_lineup_config_model.py
@@ -16,3 +16,7 @@ class TestSlateLineupConfigModel(unittest.TestCase):
         # (this is some wild list comprehension syntax - gets all experiments in all slate_lineups)
         experiments = [ex for lc in slate_lineup_configs for ex in lc.experiments]
         self.assertEqual(4, len(experiments))
+
+    def test_invalid_slates(self):
+        with self.assertRaises(ValueError):
+            SlateLineupConfigModel.load_slate_lineup_configs(os.path.join(ROOT_DIR, 'tests/assets/json/invalid_slate_lineup_configs.json'))


### PR DESCRIPTION
Check configs to make sure GUIDs used by Slates and SlateLineups are unique.

## Update
Based on PR feedback I did the following:
* Moved slate and lineup validation code into their respective models. This means we do the validations on model load, which is probably right so we don't end up with invalid models being loaded
* Cross GUID checks (between slate and lineup) done at app start.
* Tests