### PR TITLE
[SHIPIT-123] Cache serializers dumps NoneValue

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -25,7 +25,7 @@ class JsonSerializerWithNoneToken(JsonSerializer):
         """
         :return: '<NONE>' if value is None, otherwise dumps value to json.
         """
-        if value is None:
+        if value is None or value == NoneValue:
             return self._NONE_STRING
         else:
             return super().dumps(value)

--- a/tests/unit/cache/test_json_serializer_with_none_token.py
+++ b/tests/unit/cache/test_json_serializer_with_none_token.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+import pytest
+
+from app.cache import JsonSerializerWithNoneToken, NoneValue
+
+
+class TestJsonSerializerWithNoneToken:
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, '<NONE>'),
+            ({"foo": "bar"}, '{"foo":"bar"}'),
+            (NoneValue, '<NONE>'),
+        ])
+    def test_dumps(self, value: Any, expected: str):
+        serializer = JsonSerializerWithNoneToken()
+        assert expected == serializer.dumps(value)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ('<NONE>', NoneValue),
+            ('{"foo":"bar"}', {"foo": "bar"}),
+        ])
+    def test_loads(self, value: Any, expected: str):
+        serializer = JsonSerializerWithNoneToken()
+        assert expected == serializer.loads(value)

--- a/tests/unit/cache/test_json_serializer_with_none_token.py
+++ b/tests/unit/cache/test_json_serializer_with_none_token.py
@@ -24,6 +24,6 @@ class TestJsonSerializerWithNoneToken:
             ('<NONE>', NoneValue),
             ('{"foo":"bar"}', {"foo": "bar"}),
         ])
-    def test_loads(self, value: Any, expected: str):
+    def test_loads(self, value: str, expected: Any):
         serializer = JsonSerializerWithNoneToken()
         assert expected == serializer.loads(value)


### PR DESCRIPTION
# Goal
Fix this error: https://sentry.io/organizations/pocket/issues/2239906077/events/19db96fd94f9465b959434e10525b21b/

## Reference

Slack thread:
* https://pocket.slack.com/archives/C01CKCB9746/p1615221053001800

## Implementation Decisions
- From the Sentry stack trace, it's not clear to me how the code can get in a state where dumps() receives a NoneValue. I guess there's an assumption built into aiocache that outputs from `loads` can be fed into `dumps`.