### PR TITLE
adding initial lineup for web home experiment

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -644,6 +644,40 @@
     ]
   },
   {
+    "id": "4d95bade-8a43-4700-9879-3a73ba1da640",
+    "displayName": "10 Incredible Long-Reads That’ll Transport You to Another Time and Place",
+    "description": "There’s nothing like getting lost in a fascinating story — and now is a better time than any to dive into another world.",
+    "experiments": [
+      {
+        "description": "10 incredible long reads collection",
+        "candidateSets": [
+          "860ba820-9ef2-589b-bba8-a2b639e67cb6"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8944f662-cfc7-4fcb-a510-55a8589b08e7",
+    "displayName": "How to start cooking",
+    "description": "There’s nothing better for your health, wallet, or personal sense of accomplishment than learning how to cook. We’ve pulled together the best resources to help you establish confidence in the kitchen, from proper preparation and creative shortcuts to mastering simple but brilliant techniques. Grab your knives (carefully!) and let’s get started.",
+    "experiments": [
+      {
+        "description": "All collections",
+        "candidateSets": [
+          "d89008c0-730f-569c-95d8-6241d43317c3"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling"
+        ]
+      }
+    ]
+  },
+  {
     "id": "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
     "displayName": "Short Reads",
     "description": "Curated by our editors Stories to fuel your mind",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -16,6 +16,24 @@
       }
     ]
   },
+    {
+    "id": "2a817ad0-cbba-4330-9559-291468145588",
+    "description": "Web Home Test #1",
+    "experiments": [
+      {
+        "description": "Initial layout",
+        "rankers": [],
+        "slates": [
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "b9f05049-a736-46e6-85ff-a1f86a111121",
+          "4d95bade-8a43-4700-9879-3a73ba1da640",
+          "8944f662-cfc7-4fcb-a510-55a8589b08e7"
+        ]
+      }
+    ]
+  },
   {
     "id": "3b064b50-5592-4030-b19a-9f05468fbbcd",
     "description": "Perf test slate_lineup",


### PR DESCRIPTION
# Goal

adding initial slate lineup and required slates for web home experiment.

## Implementation Decisions

The doc i am following is [here](https://docs.google.com/document/d/1dmb4Dk4OY95BgJ_R2upnZ9i1z5gCED347THtc0Dv21w/edit?usp=sharing)

The slates that are included are:

- curated self-improvement
- curated food
- curated technology
- all collections slate (each candidate is a collection)
- [10 Incredible Long-Reads That’ll Transport You to Another Time and Place](https://blog.getpocket.com/2020/04/10-incredible-long-reads-thatll-transport-you-to-another-time-and-place/)
- [how to cook](https://getpocket.com/explore/item/how-to-cook)

These are all in the web home test #1 slate lineup
