### PR TITLE
[SHIPIT-123] Fix topic slate order

### DIFF
--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -22,7 +22,7 @@
     "experiments": [
       {
         "description": "SlateLineup test 1",
-        "rankers": [ ],
+        "rankers": [],
         "slates": [
           "de254c5d-57a7-4553-850f-153ee385014d",
           "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
@@ -35,7 +35,7 @@
       },
       {
         "description": "SlateLineup test 2",
-        "rankers": [ ],
+        "rankers": [],
         "slates": [
           "de254c5d-57a7-4553-850f-153ee385014d",
           "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
@@ -50,227 +50,227 @@
     ]
   },
   {
-   "id": "9c3018a8-8aa9-4f91-81e9-ebcd95fc82da",
-   "description": "Explore Home SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Home - No syndicated in top 5 results, live syndicated allowed below",
-       "rankers": [ ],
-       "slates": [
-         "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
-         "0737b00e-a21e-4875-a4c7-3e14926d4acf"
-       ]
-     }
-   ]
+    "id": "9c3018a8-8aa9-4f91-81e9-ebcd95fc82da",
+    "description": "Explore Home SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Home - No syndicated in top 5 results, live syndicated allowed below",
+        "rankers": [],
+        "slates": [
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
+          "0737b00e-a21e-4875-a4c7-3e14926d4acf"
+        ]
+      }
+    ]
   },
   {
-   "id": "c18b41d8-8100-4037-aa64-416994e1d4cf",
-   "description": "Explore Business Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
-         "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5"
-       ]
-     }
-   ]
- },
- {
-   "id": "ff23f296-6c5e-4f53-a46a-3feb5006f261",
-   "description": "Explore Career Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "e6c8db8d-cae7-4947-a57e-872dec639472",
-         "b4032752-155b-4f09-ac1e-f5337df19e88"
-       ]
-     }
-   ]
- },
- {
-   "id": "7bf5c80a-ffd1-436a-9dea-4f9badea463a",
-   "description": "Explore Education Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "8aaac382-9c27-42ab-9470-ac1dfc666262",
-         "b0de37c0-81ef-4063-a432-1bb64270b039"
-       ]
-     }
-   ]
- },
- {
-   "id": "cd1f803f-30bd-424b-9d75-6e8d3c8e8450",
-   "description": "Explore Entertainment Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "ce96db55-f32e-48f1-929f-216eb2e8c082",
-         "e9df8a81-19af-48e2-a90f-05e9a37491ca"
-       ]
-     }
-   ]
- },
- {
-   "id": "c057d284-31e6-4ba0-ae09-3478f3d40ec7",
-   "description": "Explore Food Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "884414d5-502d-4e1a-8e70-1dc8eb4a345a",
-         "1a634351-361b-4115-a9d5-b79131b1f95a"
-       ]
-     }
-   ]
- },
- {
-   "id": "b966a787-d9f2-432a-bd30-741d1ac797d1",
-   "description": "Explore Gaming Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "44dff273-3604-40e9-a0b5-bf3852581990",
-         "4cc738f7-25a9-4511-9cc3-68a8f9be91f8"
-       ]
-     }
-   ]
- },
- {
-   "id": "1abc55f1-75b1-44cb-b5bd-65c4282b158d",
-   "description": "Explore Health Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "494eaa68-f048-4f52-bb9a-5e7d2526f5cb",
-         "7cb4f497-fd05-42c5-9f78-3650e9ddba21"
-       ]
-     }
-   ]
- },
- {
-   "id": "d273a8e2-ab17-43e8-809d-0abde4d617d7",
-   "description": "Explore Parenting Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "e6600ffe-b65a-42d3-b570-f460f3d7326e",
-         "90adee1c-7794-4f41-9645-2ff9cf91113c"
-       ]
-     }
-   ]
- },
- {
-   "id": "62585952-3eb8-4380-be06-266eca903cbc",
-   "description": "Explore Personal Finance Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "72ce0827-9dbc-470f-9722-39476daaeb0f",
-         "0c09627b-a409-4768-b87d-7e1d29259785"
-       ]
-     }
-   ]
- },
- {
-   "id": "72c3878f-c48b-413c-aff8-90d7a0d79d32",
-   "description": "Explore Politics Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "9901851d-ea76-4667-8dc7-0c1677ecb910",
-         "9bece73b-4d54-43a6-bb10-d7b02abcd181"
-       ]
-     }
-   ]
- },
- {
-   "id": "c2829dc4-6a86-4c87-aa3e-f75f67ae8230",
-   "description": "Explore Science Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "ab6048ca-5c61-4e87-aefd-7a612b60ab7b",
-         "b64c873e-7f05-496e-8be4-bfae929c8a04"
-       ]
-     }
-   ]
- },
- {
-   "id": "63f24663-0e80-4c08-82aa-3fb0e06c4979",
-   "description": "Explore Self-Improvement Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "47688fcf-2bbb-4e0e-a02e-1f68c248a67e",
-         "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c"
-       ]
-     }
-   ]
- },
- {
-   "id": "695e39f3-62e8-4430-8d12-e8b457ac7751",
-   "description": "Explore Sports Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "8a495385-9972-4d0e-b93e-4234f4897939",
-         "ea40bef5-4406-488d-ad9d-915dfa1f0794"
-       ]
-     }
-   ]
- },
- {
-   "id": "dc010ef1-1f34-473a-a4b5-4cc155e18a4a",
-   "description": "Explore Technology Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "fa61096a-b681-4251-b299-2fda06c49ebf",
-         "e0d7063a-9421-4148-b548-446e9fbc8566"
-       ]
-     }
-   ]
- },
- {
-   "id": "f16f670d-14f7-425d-a310-0bb8c267dba2",
-   "description": "Explore Travel Topic SlateLineup",
-   "experiments": [
-     {
-       "description": "Explore Topic SlateLineup",
-       "rankers": [ ],
-       "slates": [
-         "d024ce9c-ed96-453f-a81e-8a0b850681e7",
-         "9389d944-fdcf-4394-9ca3-4604c0af4fac"
-       ]
-     }
-   ]
- }
+    "id": "c18b41d8-8100-4037-aa64-416994e1d4cf",
+    "description": "Explore Business Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
+          "d9c6ddfa-a58d-402d-9664-4190ba197ea6"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ff23f296-6c5e-4f53-a46a-3feb5006f261",
+    "description": "Explore Career Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "b4032752-155b-4f09-ac1e-f5337df19e88",
+          "e6c8db8d-cae7-4947-a57e-872dec639472"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7bf5c80a-ffd1-436a-9dea-4f9badea463a",
+    "description": "Explore Education Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "b0de37c0-81ef-4063-a432-1bb64270b039",
+          "8aaac382-9c27-42ab-9470-ac1dfc666262"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cd1f803f-30bd-424b-9d75-6e8d3c8e8450",
+    "description": "Explore Entertainment Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
+          "ce96db55-f32e-48f1-929f-216eb2e8c082"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c057d284-31e6-4ba0-ae09-3478f3d40ec7",
+    "description": "Explore Food Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "884414d5-502d-4e1a-8e70-1dc8eb4a345a"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b966a787-d9f2-432a-bd30-741d1ac797d1",
+    "description": "Explore Gaming Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "4cc738f7-25a9-4511-9cc3-68a8f9be91f8",
+          "44dff273-3604-40e9-a0b5-bf3852581990"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1abc55f1-75b1-44cb-b5bd-65c4282b158d",
+    "description": "Explore Health Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
+          "494eaa68-f048-4f52-bb9a-5e7d2526f5cb"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d273a8e2-ab17-43e8-809d-0abde4d617d7",
+    "description": "Explore Parenting Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "90adee1c-7794-4f41-9645-2ff9cf91113c",
+          "e6600ffe-b65a-42d3-b570-f460f3d7326e"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "62585952-3eb8-4380-be06-266eca903cbc",
+    "description": "Explore Personal Finance Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "0c09627b-a409-4768-b87d-7e1d29259785",
+          "72ce0827-9dbc-470f-9722-39476daaeb0f"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "72c3878f-c48b-413c-aff8-90d7a0d79d32",
+    "description": "Explore Politics Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "9901851d-ea76-4667-8dc7-0c1677ecb910"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c2829dc4-6a86-4c87-aa3e-f75f67ae8230",
+    "description": "Explore Science Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "b64c873e-7f05-496e-8be4-bfae929c8a04",
+          "ab6048ca-5c61-4e87-aefd-7a612b60ab7b"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "63f24663-0e80-4c08-82aa-3fb0e06c4979",
+    "description": "Explore Self-Improvement Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "47688fcf-2bbb-4e0e-a02e-1f68c248a67e"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "695e39f3-62e8-4430-8d12-e8b457ac7751",
+    "description": "Explore Sports Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "ea40bef5-4406-488d-ad9d-915dfa1f0794",
+          "8a495385-9972-4d0e-b93e-4234f4897939"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "dc010ef1-1f34-473a-a4b5-4cc155e18a4a",
+    "description": "Explore Technology Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "fa61096a-b681-4251-b299-2fda06c49ebf"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f16f670d-14f7-425d-a310-0bb8c267dba2",
+    "description": "Explore Travel Topic SlateLineup",
+    "experiments": [
+      {
+        "description": "Explore Topic SlateLineup",
+        "rankers": [],
+        "slates": [
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac",
+          "d024ce9c-ed96-453f-a81e-8a0b850681e7"
+        ]
+      }
+    ]
+  }
 ]

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -16,7 +16,7 @@
       }
     ]
   },
-    {
+  {
     "id": "2a817ad0-cbba-4330-9559-291468145588",
     "description": "Web Home Test #1",
     "experiments": [
@@ -77,6 +77,19 @@
         "slates": [
           "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
           "0737b00e-a21e-4875-a4c7-3e14926d4acf"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "53ace46e-fd12-4744-9647-fa633a9a044c",
+    "description": "Coronavirus SlateLineup",
+    "experiments": [
+      {
+        "description": "Coronavirus essential reads - Stay informed with this curated guide to the global outbreak.",
+        "rankers": [],
+        "slates": [
+          "796ca16f-4cd4-4dcb-84d5-477715c41668"
         ]
       }
     ]
@@ -248,19 +261,6 @@
         ]
       }
     ]
-  },
-    {
-   "id": "53ace46e-fd12-4744-9647-fa633a9a044c",
-   "description": "Coronavirus SlateLineup",
-   "experiments": [
-     {
-       "description": "Coronavirus essential reads - Stay informed with this curated guide to the global outbreak.",
-       "rankers": [ ],
-       "slates": [
-         "796ca16f-4cd4-4dcb-84d5-477715c41668"
-       ]
-     }
-   ]
   },
   {
     "id": "695e39f3-62e8-4430-8d12-e8b457ac7751",

--- a/tests/functional/json/slate_lineup_config.py
+++ b/tests/functional/json/slate_lineup_config.py
@@ -1,9 +1,11 @@
+import re
+
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
 from app.models.slate_config import SlateConfigModel
 from app.models.slate_lineup_config import SlateLineupConfigModel
 
 
-def test_slate_lineup_config():
+def test_slate_exists():
     """
     Test that all slates referenced in the slate_lineup config exist.
     """
@@ -15,3 +17,24 @@ def test_slate_lineup_config():
             for slate in experiment.slates:
                 if not SlateLineupExperimentModel.slate_id_exists(slate):
                     raise ValueError(f'slate {slate_lineup_config.id}|{experiment.description}|{slate} was not found')
+
+
+def test_explore_topic_slates():
+    """
+    Test that all Explore Topic lineups have a curated and algorithmic slate, in this order.
+    """
+    slate_configs_by_id = {s.id: s for s in SlateConfigModel.load_slate_configs()}
+    slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
+
+    for slate_lineup_config in slate_lineup_configs:
+        match = re.match(r'^Explore (.*?) Topic SlateLineup$', slate_lineup_config.description)
+        if match:
+            topic_name = match.group(1)
+            for experiment in slate_lineup_config.experiments:
+                slates = [slate_configs_by_id[slate_id] for slate_id in experiment.slates]
+
+                assert topic_name in slates[0].displayName
+                assert topic_name in slates[1].displayName
+
+                assert "Curated" in slates[0].displayName
+                assert "Algorithmic" in slates[1].displayName

--- a/tests/functional/json/slate_lineup_config.py
+++ b/tests/functional/json/slate_lineup_config.py
@@ -41,9 +41,12 @@ def test_explore_topic_slates():
     slate_configs_by_id = {s.id: s for s in SlateConfigModel.load_slate_configs()}
     slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
 
+    match_count = 0
+
     for slate_lineup_config in slate_lineup_configs:
         match = re.match(r'^Explore (.*?) Topic SlateLineup$', slate_lineup_config.description)
         if match:
+            match_count += 1
             topic_name = match.group(1)
             for experiment in slate_lineup_config.experiments:
                 slates = [slate_configs_by_id[slate_id] for slate_id in experiment.slates]
@@ -55,3 +58,5 @@ def test_explore_topic_slates():
                 # Assert that slates are ordered curated, algorithmic.
                 assert "Curated" in slates[0].displayName
                 assert "Algorithmic" in slates[1].displayName
+
+    assert match_count == 15

--- a/tests/functional/json/slate_lineup_config.py
+++ b/tests/functional/json/slate_lineup_config.py
@@ -34,6 +34,9 @@ def test_slate_exists():
 def test_explore_topic_slates():
     """
     Test that all Explore Topic lineups have a curated and algorithmic slate, in this order.
+
+    The Web repo currently relies on this ordering in src/Discover/RecommendationAPIClient.php:getTopicRecommendations
+    to return curated and algorithmic slates via the legacy v3/discover/topics endpoint.
     """
     slate_configs_by_id = {s.id: s for s in SlateConfigModel.load_slate_configs()}
     slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
@@ -45,8 +48,10 @@ def test_explore_topic_slates():
             for experiment in slate_lineup_config.experiments:
                 slates = [slate_configs_by_id[slate_id] for slate_id in experiment.slates]
 
+                # Assert that the first two slates are topic slates
                 assert topic_name in slates[0].displayName
                 assert topic_name in slates[1].displayName
 
+                # Assert that slates are ordered curated, algorithmic.
                 assert "Curated" in slates[0].displayName
                 assert "Algorithmic" in slates[1].displayName


### PR DESCRIPTION
# Goal
The Web repo assumes that topic linups have a curated and algorithmic slate, in this order. Whether clients can depend on slates coming in a particular order is a great question, that we should talk about.