### PR TITLE
Remove Thompson sampling from Coronavirus slate

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -98,7 +98,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }


### PR DESCRIPTION
# Goal
Disable Thompson sampling on the Coronavirus slate.

## Reference

Slack thread:
* https://pocket.slack.com/archives/C01CKCB9746/p1615591932046400?thread_ts=1615591370.044400&cid=C01CKCB9746

## Implementation Decisions
