### PR TITLE
Add RecIt CandidateSet Support

### DIFF
--- a/.docker/localstack/dynamodb/recommendation_api_candidate_sets_data.json
+++ b/.docker/localstack/dynamodb/recommendation_api_candidate_sets_data.json
@@ -3,44 +3,137 @@
     {
       "PutRequest": {
         "Item": {
+          "id": {
+            "S": "f340f4ad-ce0a-543a-a87f-ca8321a3c978"
+          },
+          "version": {
+            "N": "1"
+          },
+          "flow": {
+            "S": "CollectionsFlow"
+          },
+          "created_at": {
+            "N": "1615335211"
+          },
           "candidates": {
             "L": [
               {
                 "M": {
-                  "feed_id": {
-                    "N": "1"
-                  },
                   "item_id": {
-                    "N": "3242933715"
+                    "N": "527111584"
                   },
                   "publisher": {
-                    "S": "The Atlantic"
+                    "S": "youtube.com"
                   }
                 }
               },
               {
                 "M": {
                   "item_id": {
-                    "N": "3241253231"
+                    "N": "2128830897"
                   },
                   "publisher": {
-                    "S": "The New Yorker"
+                    "S": "newyorker.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3115291557"
+                  },
+                  "publisher": {
+                    "S": "aeon.co"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "2939364760"
+                  },
+                  "publisher": {
+                    "S": "ted.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "1085990651"
+                  },
+                  "publisher": {
+                    "S": "theconversation.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "440515234"
+                  },
+                  "publisher": {
+                    "S": "psychologytoday.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "950477974"
+                  },
+                  "publisher": {
+                    "S": "youtube.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "2588011487"
+                  },
+                  "publisher": {
+                    "S": "thebrainscientist.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "188279195"
+                  },
+                  "publisher": {
+                    "S": "friendsfoodfamily.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "2207530508"
+                  },
+                  "publisher": {
+                    "S": "nytimes.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "1641238235"
+                  },
+                  "publisher": {
+                    "S": "popsci.com"
                   }
                 }
               }
             ]
           },
-          "created_at": {
-            "N": "1612470655"
+          "run": {
+            "S": "sfn-ea1ef59d-6338-b9c0-ecc9-a2e153fccea6_2c204ea8-e8bb-05a6-5838-ce55e6ad7a36"
           },
           "expires_at": {
-            "N": "1738711178"
-          },
-          "id": {
-            "S": "1234-5678-ABCD-CEDF"
-          },
-          "version": {
-            "N": "1"
+            "N": "1617754390"
           }
         }
       }
@@ -48,44 +141,612 @@
     {
       "PutRequest": {
         "Item": {
+          "id": {
+            "S": "a6696de0-2695-4ab8-b389-6dd82e28ff98"
+          },
+          "version": {
+            "N": "1"
+          },
+          "flow": {
+            "S": "AlgorithmicCandidatesFlow"
+          },
+          "created_at": {
+            "N": "1615417966"
+          },
           "candidates": {
             "L": [
               {
                 "M": {
-                  "feed_id": {
-                    "N": "1"
-                  },
                   "item_id": {
-                    "N": "3242933715"
+                    "N": "3268903453"
                   },
                   "publisher": {
-                    "S": "The Atlantic"
+                    "S": "theconversation.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
                   }
                 }
               },
               {
                 "M": {
                   "item_id": {
-                    "N": "3241253231"
+                    "N": "3254128851"
                   },
                   "publisher": {
-                    "S": "The New Yorker"
+                    "S": "theatlantic.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3238063666"
+                  },
+                  "publisher": {
+                    "S": "theatlantic.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3231438719"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3264545122"
+                  },
+                  "publisher": {
+                    "S": "bbc.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3241951860"
+                  },
+                  "publisher": {
+                    "S": "cnbc.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3226023169"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3227808566"
+                  },
+                  "publisher": {
+                    "S": "bbc.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3260955498"
+                  },
+                  "publisher": {
+                    "S": "aeon.co"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3228663824"
+                  },
+                  "publisher": {
+                    "S": "markmanson.net"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3232545454"
+                  },
+                  "publisher": {
+                    "S": "inc.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3177272960"
+                  },
+                  "publisher": {
+                    "S": "ted.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3253247748"
+                  },
+                  "publisher": {
+                    "S": "huffpost.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3210272790"
+                  },
+                  "publisher": {
+                    "S": "huffpost.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3212913716"
+                  },
+                  "publisher": {
+                    "S": "entrepreneur.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3271842817"
+                  },
+                  "publisher": {
+                    "S": "inc.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3270402654"
+                  },
+                  "publisher": {
+                    "S": "theatlantic.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3218769388"
+                  },
+                  "publisher": {
+                    "S": "inc.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3239722168"
+                  },
+                  "publisher": {
+                    "S": "nytimes.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3234412185"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3236222095"
+                  },
+                  "publisher": {
+                    "S": "theladders.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3246812680"
+                  },
+                  "publisher": {
+                    "S": "ted.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3224008133"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3251163975"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3224591025"
+                  },
+                  "publisher": {
+                    "S": "nytimes.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3247198793"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3229168702"
+                  },
+                  "publisher": {
+                    "S": "lithub.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3211216646"
+                  },
+                  "publisher": {
+                    "S": "lifehack.org"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3273730580"
+                  },
+                  "publisher": {
+                    "S": "brainpickings.org"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3200656530"
+                  },
+                  "publisher": {
+                    "S": "forbes.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3215524033"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3217132175"
+                  },
+                  "publisher": {
+                    "S": "nytimes.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3248775132"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3273906931"
+                  },
+                  "publisher": {
+                    "S": "entrepreneur.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3228550618"
+                  },
+                  "publisher": {
+                    "S": "chronicle.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3253277514"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3210728883"
+                  },
+                  "publisher": {
+                    "S": "psychologytoday.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3245317994"
+                  },
+                  "publisher": {
+                    "S": "theatlantic.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3241054191"
+                  },
+                  "publisher": {
+                    "S": "theatlantic.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3262831573"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3253985174"
+                  },
+                  "publisher": {
+                    "S": "medium.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3227561853"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "N": "1"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3249731107"
+                  },
+                  "publisher": {
+                    "S": "hbr.org"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3262930172"
+                  },
+                  "publisher": {
+                    "S": "thecut.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3220654520"
+                  },
+                  "publisher": {
+                    "S": "fastcompany.com"
+                  },
+                  "feed_id": {
+                    "NULL": true
                   }
                 }
               }
             ]
           },
-          "created_at": {
-            "N": "1612470655"
+          "run": {
+            "S": "sfn-3fc5c893-25b3-6ae2-42df-055eda498600_d6e52a89-7ab3-eb2e-8fe1-b3c36f974db8"
           },
           "expires_at": {
-            "N": "1738711178"
-          },
-          "id": {
-            "S": "1234-5678-ABCD-CEDG"
-          },
-          "version": {
-            "N": "1"
+            "N": "1617837105"
           }
         }
       }
@@ -93,89 +754,127 @@
     {
       "PutRequest": {
         "Item": {
+          "id": {
+            "S": "bd1f50d5-5776-5c41-81aa-7fdbd17608df"
+          },
+          "version": {
+            "N": "1"
+          },
+          "flow": {
+            "S": "CollectionsFlow"
+          },
+          "created_at": {
+            "N": "1615422009"
+          },
           "candidates": {
             "L": [
               {
                 "M": {
-                  "feed_id": {
-                    "N": "1"
-                  },
                   "item_id": {
-                    "N": "3242933715"
+                    "N": "2729245683"
                   },
                   "publisher": {
-                    "S": "The Atlantic"
+                    "S": "nytimes.com"
                   }
                 }
               },
               {
                 "M": {
                   "item_id": {
-                    "N": "3241253231"
+                    "N": "3171600991"
                   },
                   "publisher": {
-                    "S": "The New Yorker"
-                  }
-                }
-              }
-            ]
-          },
-          "created_at": {
-            "N": "1612470655"
-          },
-          "expires_at": {
-            "N": "1738711178"
-          },
-          "id": {
-            "S": "1234-5678-ABCD-CEDH"
-          },
-          "version": {
-            "N": "1"
-          }
-        }
-      }
-    },
-    {
-      "PutRequest": {
-        "Item": {
-          "candidates": {
-            "L": [
-              {
-                "M": {
-                  "feed_id": {
-                    "N": "1"
-                  },
-                  "item_id": {
-                    "N": "3242933715"
-                  },
-                  "publisher": {
-                    "S": "The Atlantic"
+                    "S": "stitcher.com"
                   }
                 }
               },
               {
                 "M": {
                   "item_id": {
-                    "N": "3241253231"
+                    "N": "2787568852"
                   },
                   "publisher": {
-                    "S": "The New Yorker"
+                    "S": "penguinrandomhouse.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3140930558"
+                  },
+                  "publisher": {
+                    "S": "open.spotify.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "1734268492"
+                  },
+                  "publisher": {
+                    "S": "netflix.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "1583057724"
+                  },
+                  "publisher": {
+                    "S": "netflix.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "2578049313"
+                  },
+                  "publisher": {
+                    "S": "vulture.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "3170629629"
+                  },
+                  "publisher": {
+                    "S": "stitcher.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "555360854"
+                  },
+                  "publisher": {
+                    "S": "amazon.com"
+                  }
+                }
+              },
+              {
+                "M": {
+                  "item_id": {
+                    "N": "2415092151"
+                  },
+                  "publisher": {
+                    "S": "christyharrison.com"
                   }
                 }
               }
             ]
           },
-          "created_at": {
-            "N": "1612470655"
+          "run": {
+            "S": "sfn-17a3c61d-37c5-7fc5-7264-c49a5d132af3_b1c6584d-1214-6d5e-bae7-dccdb0ea46cf"
           },
           "expires_at": {
-            "N": "1738711178"
-          },
-          "id": {
-            "S": "1234-5678-ABCD-CEDI"
-          },
-          "version": {
-            "N": "1"
+            "N": "1617841205"
           }
         }
       }

--- a/app/config.py
+++ b/app/config.py
@@ -36,3 +36,7 @@ elasticache = {
     # Expire time in seconds for candidate sets
     'candidate_set_ttl': int(os.getenv('MEMCACHED_CANDIDATE_SET_TTL', 900)),
 }
+
+recit = {
+    'endpoint_url': os.getenv('RECIT_ENDPOINT_URL', 'http://recit.readitlater.com')
+}

--- a/app/json/slate_config.schema.json
+++ b/app/json/slate_config.schema.json
@@ -83,9 +83,12 @@
                 "title": "The Experiment Candidate Set Items Schema",
                 "default": "",
                 "examples": [
-                  "39d0dc54-f6f8-4f13-bea4-4320b3bd8217"
+                  "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
+                  "recit-personalized/bestof",
+                  "recit-personalized/curated",
+                  "recit-personalized/syndicated"
                 ],
-                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}|recit-personalized\\/(bestof|syndicated|curated))$"
               }
             },
             "rankers": {

--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -105,6 +105,23 @@
     ]
   },
   {
+    "id": "ad73c061-5ac5-458f-8691-ab071f7eadd7",
+    "displayName": "Best Of Personalized",
+    "description": "Best of Personalized",
+    "experiments": [
+      {
+        "description": "recit-personalized",
+        "candidateSets": [
+          "recit-personalized/bestof"
+        ],
+        "rankers": [
+          "top15",
+          "thompson-sampling"
+        ]
+      }
+    ]
+  },
+  {
     "id": "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
     "displayName": "Algorithmic Business Slate",
     "description": "Popular with Pocket readers  Stories from across the web",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -67,7 +67,7 @@
       }
     ]
   },{
-    "id": "3b064b50-5592-4030-b19a-9f05468fbbcd",
+    "id": "63df08d9-fe0e-4084-8241-9e1c08e27951",
     "description": "Perf test slate_lineup personalized",
     "experiments": [
       {

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -66,6 +66,38 @@
         ]
       }
     ]
+  },{
+    "id": "3b064b50-5592-4030-b19a-9f05468fbbcd",
+    "description": "Perf test slate_lineup personalized",
+    "experiments": [
+      {
+        "description": "SlateLineup test 1",
+        "rankers": [ ],
+        "slates": [
+          "ad73c061-5ac5-458f-8691-ab071f7eadd7",
+          "de254c5d-57a7-4553-850f-153ee385014d",
+          "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
+          "0c09627b-a409-4768-b87d-7e1d29259785",
+          "b4032752-155b-4f09-ac1e-f5337df19e88",
+          "72ce0827-9dbc-470f-9722-39476daaeb0f",
+          "ea40bef5-4406-488d-ad9d-915dfa1f0794"
+        ]
+      },
+      {
+        "description": "SlateLineup test 2",
+        "rankers": [ ],
+        "slates": [
+          "ad73c061-5ac5-458f-8691-ab071f7eadd7",
+          "de254c5d-57a7-4553-850f-153ee385014d",
+          "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
+          "e6600ffe-b65a-42d3-b570-f460f3d7326e",
+          "72ce0827-9dbc-470f-9722-39476daaeb0f",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
+        ]
+      }
+    ]
   },
   {
     "id": "9c3018a8-8aa9-4f91-81e9-ebcd95fc82da",

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from app.config import ENV, ENV_PROD, ENV_DEV, service, sentry as sentry_config
 from app.graphql.graphql import schema
 from app.graphql.user_middleware import UserMiddleware
 from app.graphql_app import GraphQLAppWithMiddleware, GraphQLSentryMiddleware
-from app.models.candidate_set import CandidateSetModel
+from app.models.candidate_set import candidate_set_factory
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
 from app.models.slate_lineup_config import SlateLineupConfigModel, validate_unique_guids
 from app.models.slate_config import SlateConfigModel
@@ -96,7 +96,8 @@ async def load_slate_configs():
             for experiment in slate_config.experiments:
                 for cs in experiment.candidate_sets:
                     logging.info(f"Validating candidate set {cs}")
-                    if not await CandidateSetModel.verify_candidate_set(cs):
+                    csm = await candidate_set_factory(cs, None)
+                    if not await csm.verify_candidate_set(cs):
                         # Send event to Sentry, but don't raise it, because missing candidate sets should not
                         # block successfully starting the application.
                         message = f'candidate set {slate_config.id}|{experiment.description}|{cs} was not found.'

--- a/app/models/candidate_set.py
+++ b/app/models/candidate_set.py
@@ -1,12 +1,14 @@
 import aioboto3
+import aiohttp
 from aiocache import caches
+import logging
 
 from aws_xray_sdk.core import xray_recorder
 from boto3.dynamodb.conditions import Key
 from pydantic import BaseModel
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
-from app.config import dynamodb as dynamodb_config
+from app.config import dynamodb as dynamodb_config, recit as recit_config
 import app.cache
 from app.models.candidate import Candidate
 
@@ -21,7 +23,83 @@ class CandidateSetModel(BaseModel):
     version: int
 
     @staticmethod
-    @xray_recorder.capture_async('models.candidate_set.verify_candidate_set')
+    async def verify_candidate_set(cs_id: str) -> bool:
+        raise NotImplemented
+
+
+# All RecIt CandidateSets are prefixed with this
+RECIT_PREFIX = "recit-personalized"
+
+# The keys represent valid names for use in RecsAPI, the corresponding values are the module names for RecIt.
+RECIT_MODULES = {'bestof': 'recsapi_bestof', 'syndicated': 'recsapi_syndicated', 'curated': 'recsapi_curated'}
+RECIT_LIMIT = 15
+
+
+class RecItCandidateSet(CandidateSetModel):
+
+    @staticmethod
+    def _get_module(cs_id: str) -> str:
+        """Return the RecIt module name for a given `cs_id`."""
+        _, module = cs_id.split('/')
+        return RECIT_MODULES[module]
+
+    @staticmethod
+    def _verify_candidate_set(cs_id: str) -> bool:
+        """Verify that `cs_id` is composed of `RECIT_PREFIX`/`RECIT_MODULES`"""
+        if not cs_id.startswith(RECIT_PREFIX):
+            return False
+        try:
+            RecItCandidateSet._get_module(cs_id)
+            return True
+        except KeyError:
+            return False
+
+    @staticmethod
+    async def verify_candidate_set(cs_id: str) -> bool:
+        """Async version of _verify_candidate_set"""
+        return RecItCandidateSet._verify_candidate_set(cs_id)
+
+    @staticmethod
+    @xray_recorder.capture_async('models.recit_candidate_set.get')
+    async def get(cs_id: str, user_id: str) -> "RecItCandidateSet":
+        """Get a candidateSet personalized for a user from RecIt. This makes a network call to RecIt.
+        :param cs_id: string identifying which candidateSet to fetch from RecIt. Format is `RECIT_PREFIX`/`RECIT_MODULES`.
+        :param user_id string of the target user_id
+
+        :returns If a profile exists for `user_id`, a candidateSet populated with items pertaining to the users interest.
+        If no profile exists an empty candidateSet is returned.
+
+        :raises `ValueError` if `cs_id` is unsupported or `user_id` is missing.
+        """
+        if not user_id:
+            raise ValueError("user_id must be provided for personalized slates")
+
+        if not RecItCandidateSet._verify_candidate_set(cs_id):
+            raise ValueError(f"Unsupported cs_id {cs_id}")
+
+        recit_module_name = RecItCandidateSet._get_module(cs_id)
+
+        #TODO: There should really just be one session shared, not sure how to do this in gunicorn thou
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f'{recit_config["endpoint_url"]}/v1/module/{recit_module_name}/0',
+                                   params={"user_id": user_id, "limit": RECIT_LIMIT}) as resp:
+                if resp.status == 200:
+                    return RecItCandidateSet.parse_recit_response(cs_id, await resp.json())
+                else:
+                    logging.warning("RecIt error with status (%s): %s", resp.status, resp.content)
+                    return RecItCandidateSet(candidates=[], id=cs_id, version=1)
+
+    @staticmethod
+    def parse_recit_response(cs_id: str, response: Dict) -> "RecItCandidateSet":
+        """Transforms a RecIt response to a CandidateSet. We set publisher to '0' since RecIt doesn't currently return
+        publishers."""
+        candidates = [Candidate(item_id=r["resolved_id"], publisher="0") for r in response["items"]]
+        return RecItCandidateSet(candidates=candidates, id=cs_id, version=1)
+
+
+class DynamoDBCandidateSet(CandidateSetModel):
+    @staticmethod
+    @xray_recorder.capture_async('models.dynamodb_candidate_set.verify_candidate_set')
     async def verify_candidate_set(cs_id: str) -> bool:
         """
         Ensures the given candidate set exists in the database
@@ -29,30 +107,29 @@ class CandidateSetModel(BaseModel):
         :param cs_id: string id of the candidate set
         :return: boolean
         """
-        response = await CandidateSetModel._query_by_id(cs_id)
+        response = await DynamoDBCandidateSet._query_by_id(cs_id)
         if not response['Items']:
             return False
 
         return True
 
-
     @staticmethod
-    @xray_recorder.capture_async('models.candidate_set.get')
-    async def get(cs_id: str) -> 'CandidateSetModel':
+    @xray_recorder.capture_async('models.dynamodb_candidate_set.get')
+    async def get(cs_id: str) -> 'DynamoDBCandidateSet':
         """
         Retrieves a candidate set from the database and instantiates a CandidateSetModel
 
         :param cs_id: string id of the candidate set
         :return: A CandidateSetModel object
         """
-        response = await CandidateSetModel._cached_query_by_id(cs_id)
+        response = await DynamoDBCandidateSet._cached_query_by_id(cs_id)
         if not response['Items']:
             raise KeyError(f'candidate set id {cs_id} was not found in the database')
 
-        return CandidateSetModel.parse_obj(response['Items'][0])
+        return DynamoDBCandidateSet.parse_obj(response['Items'][0])
 
     @staticmethod
-    @xray_recorder.capture_async('models.candidate_set._cached_query_by_id')
+    @xray_recorder.capture_async('models.dynamodb_candidate_set._cached_query_by_id')
     async def _cached_query_by_id(cs_id: str) -> Dict[str, Any]:
         """
         Wrap the _query_by_id function in a cache.
@@ -68,13 +145,13 @@ class CandidateSetModel(BaseModel):
         if value is not None:
             return value
 
-        result = await CandidateSetModel._query_by_id(cs_id)
+        result = await DynamoDBCandidateSet._query_by_id(cs_id)
 
         await cache.set(key, result, ttl=app.config.elasticache['candidate_set_ttl'])
         return result
 
     @staticmethod
-    @xray_recorder.capture_async('models.candidate_set._query_by_id')
+    @xray_recorder.capture_async('models.dynamodb_candidate_set._query_by_id')
     async def _query_by_id(cs_id: str) -> Dict[str, Any]:
         """
         Retrieves a candidate set from the database
@@ -88,3 +165,11 @@ class CandidateSetModel(BaseModel):
             response = await table.query(KeyConditionExpression=key_condition)
 
         return response
+
+
+@xray_recorder.capture_async('models.candidate_set.candidate_set_factory')
+async def candidate_set_factory(candidate_set_id: str, user_id: str) -> Union[DynamoDBCandidateSet, RecItCandidateSet]:
+    if candidate_set_id.startswith(RecItCandidateSet.PREFIX):
+        return await RecItCandidateSet.get(candidate_set_id, user_id)
+    else:
+        return await DynamoDBCandidateSet.get(candidate_set_id)

--- a/app/models/candidate_set.py
+++ b/app/models/candidate_set.py
@@ -169,7 +169,7 @@ class DynamoDBCandidateSet(CandidateSetModel):
 
 @xray_recorder.capture_async('models.candidate_set.candidate_set_factory')
 async def candidate_set_factory(candidate_set_id: str, user_id: str) -> Union[DynamoDBCandidateSet, RecItCandidateSet]:
-    if candidate_set_id.startswith(RecItCandidateSet.PREFIX):
+    if candidate_set_id.startswith(RECIT_PREFIX):
         return await RecItCandidateSet.get(candidate_set_id, user_id)
     else:
         return await DynamoDBCandidateSet.get(candidate_set_id)

--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from app.config import dynamodb as dynamodb_config
 # Needs to exist for pydantic to resolve the model field "item: ItemModel" in the RecommendationModel
 from app.graphql.item import Item
-from app.models.candidate_set import CandidateSetModel
+from app.models.candidate_set import candidate_set_factory
 from app.models.clickdata import ClickdataModel, RecommendationModules
 from app.models.item import ItemModel
 from app.models.slate_experiment import SlateExperimentModel
@@ -73,14 +73,14 @@ class RecommendationModel(BaseModel):
         return list(map(RecommendationModel.candidate_dict_to_recommendation, response['Items'][0]['candidates']))
 
     @staticmethod
-    async def get_recommendations_from_experiment(experiment: SlateExperimentModel) -> ['RecommendationModel']:
+    async def get_recommendations_from_experiment(experiment: SlateExperimentModel, user_id: str) -> ['RecommendationModel']:
         """
         Retrieves a list of RecommendationModel objects for on the given slate experiment.
         :param experiment: a SlateExperimentModel instance
         :return: a list of RecommendationModel instances
         """
         # for each candidate set id, get the candidate set record from the db
-        candidate_sets = await gather(*(CandidateSetModel.get(cs_id) for cs_id in experiment.candidate_sets))
+        candidate_sets = await gather(*(candidate_set_factory(cs_id, user_id) for cs_id in experiment.candidate_sets))
 
         recommendations = []
         # get the recommendations

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -34,22 +34,23 @@ class SlateModel(BaseModel):
         :return: a SlateModel object
         """
         slate_config = SlateConfigModel.find_by_id(slate_id)
-        return await SlateModel.__get_slate_from_slate_config(slate_config, recommendation_count=recommendation_count)
+        return await SlateModel.__get_slate_from_slate_config(slate_config, user_id, recommendation_count=recommendation_count)
 
     @staticmethod
     @xray_recorder.capture_async('models_slate_get_all')
-    async def get_all(recommendation_count: Optional[int] = 10) -> List['SlateModel']:
+    async def get_all(user_id:str, recommendation_count: Optional[int] = 10) -> List['SlateModel']:
         """
         Retrieves all slates from the database
         :param recommendation_count: int, 0 = no recs, > 0 include this many recs
         :return: a list fo SlateModel objects
         """
         slate_configs = SlateConfigModel.SLATE_CONFIGS_BY_ID.values()
-        return await SlateModel.get_slates_from_slate_configs(slate_configs, recommendation_count=recommendation_count)
+        return await SlateModel.get_slates_from_slate_configs(slate_configs, user_id, recommendation_count=recommendation_count)
 
     @staticmethod
     @xray_recorder.capture_async('models_slate_get_slates_from_slate_configs')
     async def get_slates_from_slate_configs(slate_configs: List['SlateConfigModel'],
+                                            user_id: str,
                                             recommendation_count: Optional[int] = 10) -> List['SlateModel']:
         """
 
@@ -62,6 +63,7 @@ class SlateModel(BaseModel):
         # for each slate, get random experiment
         for slate_config in slate_configs:
             slate_model = SlateModel.__get_slate_from_slate_config(slate_config,
+                                                                   user_id,
                                                                    recommendation_count=recommendation_count)
             slate_models.append(slate_model)
 
@@ -73,6 +75,7 @@ class SlateModel(BaseModel):
     @staticmethod
     @xray_recorder.capture_async('models_slate_get_slate_from_slate_config')
     async def __get_slate_from_slate_config(slate_config: 'SlateConfigModel',
+                                            user_id: str,
                                             recommendation_count: Optional[int] = 10) -> 'SlateModel':
         """
         Returns a slate model based on the supplied config
@@ -88,7 +91,7 @@ class SlateModel(BaseModel):
         # If we have a > 0 recommendation count lets get some recommendations
         if recommendation_count > 0:
             experiment = SlateExperimentModel.choose_experiment(slate_config.experiments)
-            recommendations = await RecommendationModel.get_recommendations_from_experiment(experiment)
+            recommendations = await RecommendationModel.get_recommendations_from_experiment(experiment, user_id)
             recommendations = recommendations[:recommendation_count]
 
         return SlateModel(

--- a/app/models/slate_lineup.py
+++ b/app/models/slate_lineup.py
@@ -33,6 +33,7 @@ class SlateLineupModel(BaseModel):
         """
         experiment = SlateLineupConfigModel.get_experiment_from_slate_lineup(slate_lineup_id)
         slates = await SlateLineupModel.__get_slates_from_experiment(experiment,
+                                                                     user_id,
                                                                      recommendation_count=recommendation_count,
                                                                      slate_count=slate_count)
 
@@ -45,6 +46,7 @@ class SlateLineupModel(BaseModel):
 
     @staticmethod
     async def __get_slates_from_experiment(experiment: SlateLineupExperimentModel,
+                                           user_id: str,
                                            recommendation_count: Optional[int] = 10,
                                            slate_count: Optional[int] = 8) -> List[SlateModel]:
         """
@@ -65,4 +67,4 @@ class SlateLineupModel(BaseModel):
         # Client requested only a certain number of slates, so after it was ranked, split the list to the count
         slate_configs = slate_configs[:slate_count]
 
-        return await SlateModel.get_slates_from_slate_configs(slate_configs, recommendation_count=recommendation_count)
+        return await SlateModel.get_slates_from_slate_configs(slate_configs, user_id, recommendation_count=recommendation_count)

--- a/tests/assets/json/recit_response.json
+++ b/tests/assets/json/recit_response.json
@@ -1,0 +1,27 @@
+{
+  "experiment": "doc2vec-incremental-best-article-pubspread",
+  "items": [
+    {
+      "resolved_id": 1304708068,
+      "score": 0.7636857628822327
+    },
+    {
+      "resolved_id": 1264453527,
+      "score": 0.5947591066360474
+    },
+    {
+      "resolved_id": 2393647782,
+      "score": 0.5553059577941895
+    },
+    {
+      "resolved_id": 1722985566,
+      "score": 0.5489296913146973
+    },
+    {
+      "resolved_id": 721025691,
+      "score": 0.5334054827690125
+    }
+  ],
+  "model": "doc2vec-incremental-best-article-pubspread",
+  "rec_id": "169ff30a-3bd1-4901-8c01-012ce73ddda1"
+}

--- a/tests/functional/models/test_candidate_set_model.py
+++ b/tests/functional/models/test_candidate_set_model.py
@@ -1,5 +1,5 @@
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
-from app.models.candidate_set import CandidateSetModel
+from app.models.candidate_set import DynamoDBCandidateSet
 from app.models.recommendation import RecommendationModel
 
 
@@ -18,7 +18,7 @@ class TestCandidateSetsModel(TestDynamoDBBase):
             ]
         })
 
-        executed = await CandidateSetModel.verify_candidate_set(cs_id='asdasd-12sd1asd3-5512')
+        executed = await DynamoDBCandidateSet.verify_candidate_set(cs_id='asdasd-12sd1asd3-5512')
         assert executed == True
 
     async def test_get_candidate_set(self):
@@ -35,7 +35,7 @@ class TestCandidateSetsModel(TestDynamoDBBase):
             ]
         })
 
-        candidate_set = await CandidateSetModel.get(cs_id='asdasd-12sd1asd3-5512')
+        candidate_set = await DynamoDBCandidateSet.get(cs_id='asdasd-12sd1asd3-5512')
         assert candidate_set.id == 'asdasd-12sd1asd3-5512'
         assert len(candidate_set.candidates) == 1
         candidate = candidate_set.candidates[0]
@@ -56,7 +56,7 @@ class TestCandidateSetsModel(TestDynamoDBBase):
         })
 
         # Get and cache the candidate set.
-        candidate_set = await CandidateSetModel.get(cs_id='asdasd-12sd1asd3-5512')
+        candidate_set = await DynamoDBCandidateSet.get(cs_id='asdasd-12sd1asd3-5512')
         assert candidate_set.version == 1
         assert candidate_set.candidates[0].item_id == 3208490410
 
@@ -67,13 +67,13 @@ class TestCandidateSetsModel(TestDynamoDBBase):
             ExpressionAttributeValues={':v': 2})
 
         # Assert version has not changed, because we're getting the candidate set from cache.
-        candidate_set = await CandidateSetModel.get(cs_id='asdasd-12sd1asd3-5512')
+        candidate_set = await DynamoDBCandidateSet.get(cs_id='asdasd-12sd1asd3-5512')
         assert candidate_set.version == 1
         assert candidate_set.candidates[0].item_id == 3208490410
 
         await super().clear_caches()
 
         # Assert version changed, because the cache has been cleared.
-        candidate_set = await CandidateSetModel.get(cs_id='asdasd-12sd1asd3-5512')
+        candidate_set = await DynamoDBCandidateSet.get(cs_id='asdasd-12sd1asd3-5512')
         assert candidate_set.version == 2
         assert candidate_set.candidates[0].item_id == 3208490410

--- a/tests/functional/models/test_slate_model.py
+++ b/tests/functional/models/test_slate_model.py
@@ -43,20 +43,20 @@ class TestSlateModel(TestDynamoDBBase):
 
     async def test_list_slates(self):
         SlateConfigModel.SLATE_CONFIGS_BY_ID = {slate_config_id: slate_config_model}
-        slates = await SlateModel.get_all(recommendation_count=0)
+        slates = await SlateModel.get_all(None, recommendation_count=0)
 
         assert type(slates) is list
         assert slates[0].id == slate_config_id
         assert len(slates[0].recommendations) == 0
 
     async def test_get_slates_from_slate_configs_without_recs(self):
-        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model], recommendation_count=0)
+        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model], None, recommendation_count=0)
 
         assert slates[0].id == slate_config_id
         assert len(slates[0].recommendations) == 0
 
     async def test_get_slates_from_slate_configs_with_recs(self):
-        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model])
+        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model], None)
 
         assert slates[0].id == slate_config_id
         assert len(slates[0].recommendations) == 1
@@ -89,7 +89,7 @@ class TestSlateModel(TestDynamoDBBase):
                 }
             ]
         })
-        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model], recommendation_count=2)
+        slates = await SlateModel.get_slates_from_slate_configs([slate_config_model], None, recommendation_count=2)
 
         assert slates[0].id == slate_config_id
         assert len(slates[0].recommendations) == 2

--- a/tests/unit/models/test_candidateset_model.py
+++ b/tests/unit/models/test_candidateset_model.py
@@ -1,0 +1,17 @@
+import unittest
+import json
+from app.models.candidate_set import RecItCandidateSet, candidate_set_factory
+
+
+class TestCandidateSetModel(unittest.TestCase):
+    def test_recit_parse(self):
+        with open("../../assets/json/recit_response.json") as f:
+            recit_json = json.load(f)
+        candidate_set = RecItCandidateSet.parse_recit_response("test-id", recit_json)
+        self.assertEqual(len(candidate_set.candidates), len(recit_json['items']))
+        self.assertEqual(candidate_set.candidates[0].item_id, recit_json['items'][0]["resolved_id"])
+
+    def test_recit_validate_id(self):
+        self.assertTrue(RecItCandidateSet._verify_candidate_set("recit-personalized/bestof"))
+        self.assertFalse(RecItCandidateSet._verify_candidate_set("recit-personalized/not-a-real-module"))
+        self.assertFalse(RecItCandidateSet._verify_candidate_set("wrackit-personalized/bestof"))

--- a/tests/unit/models/test_candidateset_model.py
+++ b/tests/unit/models/test_candidateset_model.py
@@ -1,11 +1,12 @@
 import unittest
 import json
-from app.models.candidate_set import RecItCandidateSet, candidate_set_factory
-
+import os
+from app.models.candidate_set import RecItCandidateSet
+from app.config import ROOT_DIR
 
 class TestCandidateSetModel(unittest.TestCase):
     def test_recit_parse(self):
-        with open("../../assets/json/recit_response.json") as f:
+        with open(os.path.join(ROOT_DIR, "tests/assets/json/recit_response.json")) as f:
             recit_json = json.load(f)
         candidate_set = RecItCandidateSet.parse_recit_response("test-id", recit_json)
         self.assertEqual(len(candidate_set.candidates), len(recit_json['items']))


### PR DESCRIPTION
# Goal
This adds a new type of CandidateSet, a `RecItCandidateSet`, which allows us to make slates that use RecIt as the source of items. This specifically allows for personalized slates using the bestof, curated, or syndicated corpora. Once the vector store exists we would move this functionality there, but there isn't any timeline on that work currently. This allows us to test out the performance of personalized slates sooner.

See the [design doc](https://docs.google.com/document/d/14PaPC3xtG7ajdH7U5VguO3J-ePoUIp5Egm2EBkWYd-M/edit) for more details.

# Notes
* Created a `DynamoDBCandidateSet` for the existing `CandidateSetModel` functionality
* You can now specify a `RecItCandidateSet` as `recit-personalized/bestof` (or `curated` or `syndicated`) in a slate.
* If a user doesn't have a profile we return an empty CandidateSet object. We either need to filter this out of the response, or clients will need to. We haven't really made a decision about that yet.
* Added a `candidate_set_factory` that will use the appropriate candidate set type based on the candidate set id
