### PR TITLE
Discover home has 5 curated non-syndicated recs

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -41,7 +41,8 @@
         "rankers": [
           "top30",
           "thompson-sampling",
-          "pubspread"
+          "pubspread",
+          "top5"
         ]
       },
       {
@@ -52,7 +53,8 @@
         "rankers": [
           "top15",
           "thompson-sampling",
-          "pubspread"
+          "pubspread",
+          "top5"
         ]
       }
     ]

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -17,6 +17,7 @@ def get_all_rankers():
     # when rankers are needed which means the `RecommendationModel` will fully be initialized before
     # `algorithms` attempt to import `RecommendationModel` - Getting us out of the circular import problem.
     from app.rankers.algorithms import (
+        top5,
         top15,
         top30,
         thompson_sampling,
@@ -24,6 +25,7 @@ def get_all_rankers():
     )
 
     return {
+        'top5': top5,
         'top15': top15,
         'top30': top30,
         'thompson-sampling': thompson_sampling,

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -10,6 +10,17 @@ from app.models.recommendation import RecommendationModel
 from app.config import ROOT_DIR
 
 
+
+def top5(items: List[Any]) -> List[Any]:
+    """
+    Gets the first 5 recommendations from the list of recommendations.
+
+    :param items: a list of recommendations in the desired order (pre-publisher spread)
+    :return: first 5 recommendations from the list of recommendations
+    """
+    return items[:5]
+
+
 def top15(items: List[Any]) -> List[Any]:
     """
     Gets the first 15 recommendations from the list of recommendations.


### PR DESCRIPTION
# Goal
There's a [Web PR that adds logic to limit the non-syndicated recs to 5](https://github.com/Pocket/Web/pull/4100/files#diff-1c621fda86f4762ee6dda55b8a12ba63d8cdbde71d112fd3005b2f33644896b9R256) for the discover homepage. Would this be a better solution to meet existing product needs?

If clients make individual `get_slate` they're able to limit the recs per slate, but the `get_slate_lineup` query can only limit recs for all slates. The best solution might be to have more fine-grained parameters in `get_slate_lineup`.

## Todos
- [ ] Outstanding todo
- [x] Completed todo

## Review
- [ ] Security @ReviewerA
- [ ] Test coverage @ReviewerC
- [ ] ...


Have you followed the guidelines in our Contributing document?

## Deployment
- [ ] Secrets?

## Reference

Tickets:
* Link to JIRA tickets

## Implementation Decisions
