### PR TITLE
[BACK-680] Switch the format of the click data input to the new source

### DIFF
--- a/app/models/clickdata.py
+++ b/app/models/clickdata.py
@@ -11,19 +11,14 @@ import app.cache
 
 # batch get has a 100 item limit
 # https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
-def chunks(index, n=100):
+def _chunks(index, n=100):
     """Yield successive n-sized chunks from index."""
     for i in range(0, len(index), n):
         yield index[i: i + n]
 
 
-class RecommendationModules(Enum):
-    HOME = 'home'
-    TOPIC = 'topic'
-
-
-def make_key(module: RecommendationModules, key: str):
-    return "%s/%s" % (module.value, key)
+def _make_key(slate_id: str, key: str) -> str:
+    return "%s/%s" % (slate_id, key)
 
 
 class ClickdataModel(BaseModel):
@@ -35,7 +30,7 @@ class ClickdataModel(BaseModel):
 
     @staticmethod
     @xray_recorder.capture_async('models.clickdata.get')
-    async def get(module: RecommendationModules, item_list: List[str]) -> Dict[str, 'ClickdataModel']:
+    async def get(slate_id: str, item_list: List[str]) -> Dict[str, 'ClickdataModel']:
         """
         Retrieves click data for the given items in the given module (home/topic)
 
@@ -44,10 +39,10 @@ class ClickdataModel(BaseModel):
         :return: dictionary of ClickdataModel objects with keys of their respective `mod_item` values
         """
         # Keys are namespaced by the module we are getting data from
-        keys = {make_key(module, item) for item in item_list}
+        keys = {_make_key(slate_id, item) for item in item_list}
 
         # Always get the default key, it is used for items that don't have any clickstream data
-        keys.add(make_key(module, "default"))
+        keys.add(_make_key(slate_id, "default"))
         keys = list(keys)
 
         clickdata = await ClickdataModel._query_cached_clickdata(keys)
@@ -55,7 +50,7 @@ class ClickdataModel(BaseModel):
         clickdata = {k.split("/")[1]: ClickdataModel.parse_obj(v) for k, v in clickdata.items() if v is not None}
 
         if not clickdata:
-            raise ValueError(f"No results from DynamoDB: module {module.value}")
+            raise ValueError(f"No results from DynamoDB: slate_id {slate_id}")
 
         return clickdata
 
@@ -79,7 +74,7 @@ class ClickdataModel(BaseModel):
         table = app.config.dynamodb['recommendation_api_clickdata_table']
 
         async with aioboto3.resource('dynamodb', endpoint_url=app.config.dynamodb['endpoint_url']) as dynamodb:
-            for keychunk in chunks(clickdata_keys):
+            for keychunk in _chunks(clickdata_keys):
                 request = {
                     table: {
                         "Keys": [{"mod_item": c} for c in keychunk]

--- a/app/models/clickdata.py
+++ b/app/models/clickdata.py
@@ -17,8 +17,15 @@ def _chunks(index, n=100):
         yield index[i: i + n]
 
 
-def _make_key(slate_id: str, key: str) -> str:
-    return "%s/%s" % (slate_id, key)
+def _make_key(slate_id: str, item_id: str) -> str:
+    """
+    Generate the primary key for the clickdata database
+
+    :param slate_id: Slate for which to get clickdata
+    :param item_id: Item for which to get clickdata, or "default" for module clickdata prior
+    :return: Clickdata DynamoDB identifier
+    """
+    return "%s/%s" % (slate_id, item_id)
 
 
 class ClickdataModel(BaseModel):

--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -10,7 +10,7 @@ from app.config import dynamodb as dynamodb_config
 # Needs to exist for pydantic to resolve the model field "item: ItemModel" in the RecommendationModel
 from app.graphql.item import Item
 from app.models.candidate_set import CandidateSetModel
-from app.models.clickdata import ClickdataModel, RecommendationModules
+from app.models.clickdata import ClickdataModel
 from app.models.item import ItemModel
 from app.models.slate_experiment import SlateExperimentModel
 from app.rankers import get_ranker
@@ -75,9 +75,11 @@ class RecommendationModel(BaseModel):
         return list(map(RecommendationModel.candidate_dict_to_recommendation, response['Items'][0]['candidates']))
 
     @staticmethod
-    async def get_recommendations_from_experiment(experiment: SlateExperimentModel) -> ['RecommendationModel']:
+    async def get_recommendations_from_experiment(
+            slate_id: str, experiment: SlateExperimentModel) -> ['RecommendationModel']:
         """
         Retrieves a list of RecommendationModel objects for on the given slate experiment.
+        :param slate_id: The id of the slate to which this experiment belongs
         :param experiment: a SlateExperimentModel instance
         :return: a list of RecommendationModel instances
         """
@@ -94,14 +96,14 @@ class RecommendationModel(BaseModel):
         for ranker in experiment.rankers:
             if ranker == 'thompson-sampling':
                 # thompson sampling takes two specific arguments so it needs to be handled differently
-                recommendations = await RecommendationModel.__thompson_sample(recommendations)
+                recommendations = await RecommendationModel.__thompson_sample(slate_id, recommendations)
                 continue
             recommendations = get_ranker(ranker)(recommendations)
 
         return recommendations
 
     @staticmethod
-    async def __thompson_sample(recommendations: ['RecommendationModel']) -> ['RecommendationModel']:
+    async def __thompson_sample(slate_id: str, recommendations: ['RecommendationModel']) -> ['RecommendationModel']:
         """
         Special processing for handling the thompson sampling ranker. Retrieves click data for the items being ranked
         and uses that for thompson sampling algorithm with beta distirbutions.
@@ -116,12 +118,13 @@ class RecommendationModel(BaseModel):
         This allows us to balance the need to explore new items' performance, and rank highly items
         that have already demonstrated high performance (in terms of CTR).
 
+        :param slate_id:
         :param recommendations: a list of RecommendationModel instances
         :return: a list of RecommendationModel instances
         """
         item_ids = [recommendation.item.item_id for recommendation in recommendations]
         try:
-            click_data = await ClickdataModel.get(RecommendationModules.TOPIC, item_ids)
+            click_data = await ClickdataModel.get(slate_id, item_ids)
         except ValueError:
             rec_item_ids = ','.join(item_ids)
             print(f'click data not found for candidates with item ids: {rec_item_ids}')

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -87,7 +87,7 @@ class SlateModel(BaseModel):
         # If we have a > 0 recommendation count lets get some recommendations
         if recommendation_count > 0:
             experiment = SlateExperimentModel.choose_experiment(slate_config.experiments)
-            recommendations = await RecommendationModel.get_recommendations_from_experiment(experiment)
+            recommendations = await RecommendationModel.get_recommendations_from_experiment(slate_config.id, experiment)
             recommendations = recommendations[:recommendation_count]
 
         return SlateModel(


### PR DESCRIPTION
# Goal
Get clickdata by slate id, instead of using topic-based clickdata by default.

Tickets:
* https://getpocket.atlassian.net/browse/BACK-680

## Implementation Decisions
- This is based on https://github.com/Pocket/recommendation-api/pull/221, but we wanted to split in two:
    1. Get clickdata by slate_id (this PR)
    2. Remove the old topics graphQL endpoint (blocked by the Web repo removing references)
