### PR TITLE
[BACK-683] Dedupe recs

### DIFF
--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -104,3 +104,15 @@ class SlateModel(BaseModel):
             recommendations=recommendations,
             requestId=str(uuid.uuid4()),
         )
+
+
+async def deduplicate_recommendations_across_slates(slates: List[SlateModel]) -> List[SlateModel]:
+    seen_item_ids = set()
+
+    for slate in slates:
+        # Remove recommendations that exist in previous slates
+        slate.recommendations = [r for r in slate.recommendations if r.item_id not in seen_item_ids]
+        # Add all item ids from slate to seen_item_ids
+        seen_item_ids |= {r.item_id for r in slate.recommendations}
+
+    return slates

--- a/app/models/slate_lineup.py
+++ b/app/models/slate_lineup.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from app.models.slate_lineup_config import SlateLineupConfigModel
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
-from app.models.slate import SlateModel
+from app.models.slate import SlateModel, deduplicate_recommendations_across_slates
 
 
 class SlateLineupModel(BaseModel):
@@ -67,4 +67,8 @@ class SlateLineupModel(BaseModel):
         # Client requested only a certain number of slates, so after it was ranked, split the list to the count
         slate_configs = slate_configs[:slate_count]
 
-        return await SlateModel.get_slates_from_slate_configs(slate_configs, user_id, recommendation_count=recommendation_count)
+        slates = await SlateModel.get_slates_from_slate_configs(slate_configs, user_id, recommendation_count=recommendation_count)
+
+        slates = await deduplicate_recommendations_across_slates(slates)
+
+        return slates

--- a/tests/functional/models/test_slate_lineup_model.py
+++ b/tests/functional/models/test_slate_lineup_model.py
@@ -8,14 +8,34 @@ from app.models.slate_experiment import SlateExperimentModel
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
 from app.models.slate_lineup_config import SlateLineupConfigModel
 
-slate_lineup_config_id = 'test-slate_lineup-config-id'
-slate_lineup_experiment = SlateLineupExperimentModel('test-ex', 'test-ex-desc', ['top15'], ['test-slate-id'])
-slate_lineup_config_model = SlateLineupConfigModel(slate_lineup_config_id, 'test-desc', [slate_lineup_experiment])
-
-slate_config_id = 'test-slate_lineup-config-id'
+# First slate
+slate_config_id = 'test-slate-config-id'
 slate_experiment = SlateExperimentModel('test-ex', 'test-ex-desc', ['top15', 'thompson-sampling'],
                                         ['test-candidate-id'])
 slate_config_model = SlateConfigModel(slate_config_id, 'test-this-slate', 'test-desc', [slate_experiment])
+
+# Second slate
+slate_config_id_2 = 'test-slate-config-id-2'
+slate_experiment_2 = SlateExperimentModel('test-ex-2', 'test-ex-desc-2', ['top15', 'thompson-sampling'],
+                                        ['test-candidate-id-2'])
+slate_config_model_2 = SlateConfigModel(slate_config_id_2, 'test-this-slate-2', 'test-desc-2', [slate_experiment_2])
+
+# Lineup with one slate
+slate_lineup_config_id = 'test-slate_lineup-config-id'
+slate_lineup_experiment = SlateLineupExperimentModel('test-ex', 'test-ex-desc', ['top15'], [slate_config_id])
+slate_lineup_config_model = SlateLineupConfigModel(slate_lineup_config_id, 'test-desc', [slate_lineup_experiment])
+
+# Lineup with two slates
+slate_lineup_config_id_2 = 'test-slate_lineup-config-id-2'
+slate_lineup_experiment_2 = SlateLineupExperimentModel('test-ex-2', 'test-ex-desc-2', ['top15'],
+                                                     slates=[slate_config_id, slate_config_id_2])
+slate_lineup_config_model_2 = SlateLineupConfigModel(slate_lineup_config_id_2, 'test-desc', [slate_lineup_experiment_2])
+
+# Slates by id
+slate_configs_by_id = {
+    slate_config_id: slate_config_model,
+    slate_config_id_2: slate_config_model_2,
+}
 
 
 class TestSlateLineupModel(TestDynamoDBBase):
@@ -90,3 +110,50 @@ class TestSlateLineupModel(TestDynamoDBBase):
 
         slate_lineup = await SlateLineupModel.get_slate_lineup(slate_lineup_config_id, slate_count=0)
         assert len(slate_lineup.slates) == 0
+
+    @patch.object(SlateConfigModel, 'SLATE_CONFIGS_BY_ID', slate_configs_by_id)
+    @patch('app.models.slate_lineup_config.SlateLineupConfigModel.find_by_id', return_value=slate_lineup_config_model_2)
+    async def test_get_slate_lineup_dedupe_recs(self, slate_lineup_config):
+        self.candidateSetTable.put_item(Item={
+            "id": "test-candidate-id",
+            "version": 1,
+            "created_at": 1612907252,
+            "candidates": [
+                {
+                    "feed_id": 1,
+                    "item_id": 10,
+                    "publisher": "hbr.org"
+                },
+                {
+                    "feed_id": 1,
+                    "item_id": 11,
+                    "publisher": "hbr.org"
+                },
+            ]
+        })
+
+        self.candidateSetTable.put_item(Item={
+            "id": "test-candidate-id-2",
+            "version": 1,
+            "created_at": 1612907252,
+            "candidates": [
+                {
+                    "feed_id": 1,
+                    "item_id": 11,
+                    "publisher": "hbr.org"
+                },
+                {
+                    "feed_id": 1,
+                    "item_id": 12,
+                    "publisher": "hbr.org"
+                }
+            ]
+        })
+
+        slate_lineup = await SlateLineupModel.get_slate_lineup(slate_lineup_config_id_2)
+        assert len(slate_lineup.slates[0].recommendations) == 2
+        assert len(slate_lineup.slates[1].recommendations) == 1
+
+        assert slate_lineup.slates[0].recommendations[0].item_id == '10'
+        assert slate_lineup.slates[0].recommendations[0].item_id == '11'
+        assert slate_lineup.slates[1].recommendations[0].item_id == '12'

--- a/tests/functional/models/test_slate_lineup_model.py
+++ b/tests/functional/models/test_slate_lineup_model.py
@@ -154,6 +154,5 @@ class TestSlateLineupModel(TestDynamoDBBase):
         assert len(slate_lineup.slates[0].recommendations) == 2
         assert len(slate_lineup.slates[1].recommendations) == 1
 
-        assert slate_lineup.slates[0].recommendations[0].item_id == '10'
-        assert slate_lineup.slates[0].recommendations[0].item_id == '11'
+        assert {'10', '11'} == {recommendation.item_id for recommendation in slate_lineup.slates[0].recommendations}
         assert slate_lineup.slates[1].recommendations[0].item_id == '12'

--- a/tests/unit/models/test_slate_model.py
+++ b/tests/unit/models/test_slate_model.py
@@ -1,0 +1,90 @@
+import json
+import unittest
+
+from app.models.slate_experiment import SlateExperimentModel
+
+
+class TestSlateExperimentModel(unittest.TestCase):
+    # test instantiation
+
+    def test_no_weight(self):
+        ex = SlateExperimentModel(experiment_id='c3h5n3o9', description='d', candidate_sets=['a'], rankers=['top15'])
+        self.assertEqual(ex.weight, SlateExperimentModel.DEFAULT_WEIGHT)
+
+    def test_no_candidate_sets(self):
+        with self.assertRaises(ValueError) as context:
+            SlateExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=[], rankers=['top15'])
+
+        self.assertTrue('no candidate sets provided for experiment' in str(context.exception))
+
+    def test_no_rankers(self):
+        sem = SlateExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'], rankers=[],
+                                   weight=0)
+
+        self.assertEqual(len(sem.rankers), 0)
+
+    def test_invalid_ranker(self):
+        with self.assertRaises(KeyError) as context:
+            SlateExperimentModel(experiment_id='c3h5n3o9', description='desc', candidate_sets=['a', 'b'],
+                                 rankers=['invalid'], weight=0)
+
+        self.assertTrue('invalid is not a valid ranker' in str(context.exception))
+
+    def test_valid_instantiation(self):
+        ex_id = 'c3h5n3o9'
+        desc = 'd'
+        cs = ['a', 'b']
+        rs = ['top15', 'pubspread']
+        w = 0.2
+
+        experiment = SlateExperimentModel(experiment_id=ex_id, description=desc, candidate_sets=cs, rankers=rs, weight=w)
+
+        self.assertEqual(experiment.id, ex_id)
+        self.assertEqual(experiment.description, desc)
+        self.assertEqual(experiment.candidate_sets, cs)
+        self.assertEqual(experiment.rankers, rs)
+        self.assertEqual(experiment.weight, w)
+
+    # test loading from json
+
+    def test_load_from_json_without_weight(self):
+        json_str = """
+            {
+               "description": "TS window 30",
+               "candidateSets": [
+                 "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
+                 "df8a86c1-8b40-48bf-b85d-c144ed96c3fc"
+               ],
+               "rankers": [
+                 "top30",
+                 "thompson-sampling",
+                 "pubspread"
+               ]
+            }
+            """
+        ex = SlateExperimentModel.load_from_dict(json.loads(json_str))
+
+        self.assertEqual(ex.description, "TS window 30")
+        self.assertEqual(ex.weight, SlateExperimentModel.DEFAULT_WEIGHT)
+        self.assertEqual(len(ex.candidate_sets), 2)
+        self.assertEqual(len(ex.rankers), 3)
+
+    def test_load_from_json_with_weight(self):
+        json_str = """
+                {
+               "description": "TS window 15",
+               "candidateSets": [
+                 "39d0dc54-f6f8-4f13-bea4-4320b3bd8217",
+                 "df8a86c1-8b40-48bf-b85d-c144ed96c3fc",
+                 "df8a86c1-8b40-48bf-b85d-c144ed96c3fd"
+               ],
+               "rankers": [],
+               "weight": 0.3
+             }
+            """
+        ex = SlateExperimentModel.load_from_dict(json.loads(json_str))
+
+        self.assertEqual(ex.description, "TS window 15")
+        self.assertEqual(ex.weight, 0.3)
+        self.assertEqual(len(ex.candidate_sets), 3)
+        self.assertEqual(len(ex.rankers), 0)


### PR DESCRIPTION
# Goal
Deduplicate recommendations across slates in a lineup. If a recommendation occurs more than once, it's removed from all but the first slate.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-683

## Implementation Decisions
- test_slate_lineup_model is almost at a point where a fixture library would be convenient, but I think it's still manageable for now.