### PR TITLE
[SHIPIT-123] Fix explore homepage lineup

### DIFF
--- a/app/json/slate_config.schema.json
+++ b/app/json/slate_config.schema.json
@@ -102,6 +102,7 @@
                 "type": "string",
                 "enum": [
                   "pubspread",
+                  "top5",
                   "top15",
                   "top30",
                   "thompson-sampling"

--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -58,6 +58,37 @@
     ]
   },
   {
+    "id": "48e766be-5e96-46fb-acbf-55fee3ae8a28",
+    "displayName": "Editors' Picks",
+    "description": "Top 5 curated items without syndicated that are at most a week old",
+    "experiments": [
+      {
+        "description": "default",
+        "candidateSets": [
+          "493a5556-9800-449f-8f8c-c27bb6c8c810"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling",
+          "pubspread",
+          "top5"
+        ]
+      },
+      {
+        "description": "ts15",
+        "candidateSets": [
+          "493a5556-9800-449f-8f8c-c27bb6c8c810"
+        ],
+        "rankers": [
+          "top15",
+          "thompson-sampling",
+          "pubspread",
+          "top5"
+        ]
+      }
+    ]
+  },
+  {
     "id": "0737b00e-a21e-4875-a4c7-3e14926d4acf",
     "displayName": "All Curated New Tab",
     "description": "Curated items with syndicated that are at most a week old",

--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -103,17 +103,6 @@
           "thompson-sampling",
           "pubspread"
         ]
-      },
-      {
-        "description": "ts15",
-        "candidateSets": [
-          "35018233-48cd-4ec4-bcfd-7b1b1ccf30de"
-        ],
-        "rankers": [
-          "top15",
-          "thompson-sampling",
-          "pubspread"
-        ]
       }
     ]
   },

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -107,7 +107,7 @@
         "description": "Explore Home - No syndicated in top 5 results, live syndicated allowed below",
         "rankers": [],
         "slates": [
-          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
+          "48e766be-5e96-46fb-acbf-55fee3ae8a28",
           "0737b00e-a21e-4875-a4c7-3e14926d4acf"
         ]
       }

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -17,6 +17,7 @@ def get_all_rankers():
     # when rankers are needed which means the `RecommendationModel` will fully be initialized before
     # `algorithms` attempt to import `RecommendationModel` - Getting us out of the circular import problem.
     from app.rankers.algorithms import (
+        top5,
         top15,
         top30,
         thompson_sampling,
@@ -24,6 +25,7 @@ def get_all_rankers():
     )
 
     return {
+        'top5': top5,
         'top15': top15,
         'top30': top30,
         'thompson-sampling': thompson_sampling,

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -1,3 +1,4 @@
+import logging
 import json
 
 from aws_xray_sdk.core import xray_recorder
@@ -8,6 +9,16 @@ from scipy.stats import beta
 
 from app.models.recommendation import RecommendationModel
 from app.config import ROOT_DIR
+
+
+def top5(items: List[Any]) -> List[Any]:
+    """
+    Gets the first 5 recommendations from the list of recommendations.
+
+    :param items: a list of recommendations in the desired order (pre-publisher spread)
+    :return: first 5 recommendations from the list of recommendations
+    """
+    return items[:5]
 
 
 def top15(items: List[Any]) -> List[Any]:
@@ -46,6 +57,10 @@ def blocklist(recs: List['RecommendationModel'], blocklist: List[str] = None) ->
         return [rec for rec in recs if rec.item.item_id not in blocklist]
 
 
+DEFAULT_ALPHA_PRIOR = 0.02
+DEFAULT_BETA_PRIOR = 1.0
+
+
 def thompson_sampling(
         recs: List['RecommendationModel'],
         clk_data: Dict[(int or str), 'ClickdataModel']) -> List['RecommendationModel']:
@@ -66,18 +81,15 @@ def thompson_sampling(
     if not recs:
         return recs
 
-    if clk_data:
-        try:
-            # 'default' is a special key we can use for anything that is missing.
-            # The values here aren't actually clicks or impressions,
-            # but instead direct alpha and beta parameters for the module CTR prior
-            alpha_prior, beta_prior = clk_data['default'].clicks, clk_data['default'].impressions
-        except KeyError:
-            # indicates no default was found indicating MLE for module prior failed to converge
-            alpha_prior, beta_prior = 0.02, 1.0
-    else:
-        # indicates no click data
-        alpha_prior, beta_prior = 0.02, 1.0
+    alpha_prior, beta_prior = DEFAULT_ALPHA_PRIOR, DEFAULT_BETA_PRIOR
+    if clk_data and 'default' in clk_data:
+        # 'default' is a special key we can use for anything that is missing.
+        # The values here aren't actually clicks or impressions,
+        # but instead direct alpha and beta parameters for the module CTR prior
+        alpha_prior, beta_prior = clk_data['default'].clicks, clk_data['default'].impressions
+        if alpha_prior < 0 or beta_prior < 0:
+            logging.error("Alpha (%s) or Beta (%s) prior < 0 for module %s", alpha_prior, beta_prior, clk_data['default'].mod_item)
+            alpha_prior, beta_prior = DEFAULT_ALPHA_PRIOR, DEFAULT_BETA_PRIOR
 
     scores = []
     # create prior distribution for CTR from parameters in click data table


### PR DESCRIPTION
# Goal
The Web client isn't getting enough recommendations. It needs at least 20. We accomplish this in two ways:
1. Limit curated nonsyndicated to 5, to prevent too many duplicates from being removed from the second slate.
2. Remove the top15 experiment from 'All Curated New Tab', so it can reliably return at least 15 recommendations.

## Reference
Slack thread:
- https://pocket.slack.com/archives/CR6T8BNCT/p1617924164014300

## Implementation Decisions
We created a slate 48e766be-5e96-46fb-acbf-55fee3ae8a28 based on 2e3ddc90-8def-46d7-b85f-da7525c66fb1 because Ian said the latter is used elsewhere, where we don't want to limit to 5 recommendations.