### PR TITLE
removing thompon sampling from curated topic slates

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -170,7 +170,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -206,7 +205,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -242,7 +240,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -278,7 +275,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -314,7 +310,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -350,7 +345,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -386,7 +380,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -422,7 +415,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -458,7 +450,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -494,7 +485,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -530,7 +520,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -566,7 +555,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -602,7 +590,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -638,7 +625,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }
@@ -674,7 +660,6 @@
         ],
         "rankers": [
           "top30",
-          "thompson-sampling",
           "pubspread"
         ]
       }


### PR DESCRIPTION
# Goal

Editorial team would like more control over content of curated section of topic pages during tests with new tab in Q2.

Removing Thompson sampling from the curated sections of the explore topic pages will revert to approval based ordering and allow them to provide excerpts in the tiles on new tab that correspond predictably to the items appearing in the curated section of those pages.

No changes to algorithmic slates.

## Reference

Slack thread: https://pocket.slack.com/archives/CN0L1NDD3/p1618511471008400

## Implementation Decisions

Removed Thompson sampling ranker from curated topic slates.  
Alternative would be to set up separate curated topic slates with TS enabled.