### PR TITLE
fix(lambda): increase timeout

### DIFF
--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -33,7 +33,7 @@ export class SqsLambda extends Resource {
       lambda: {
         runtime: LAMBDA_RUNTIMES.PYTHON38,
         handler: 'aws_lambda.sqs_handler.handler',
-        timeout: 30,
+        timeout: 120,
         executionPolicyStatements: [
           {
             effect: 'Allow',


### PR DESCRIPTION
# Goal

I noticed that we were constantly getting non-critical alarms for the translation function. When looking in sentry there were no issues, but when looking at the logs, it looks like we are hitting the lambda timeout. 

My guess is that this is occurring because larger candidate sets are being created. Lets see if a timeout increase fixes this, I arbitarly chose 120 seconds which is 4x the current timeout.

![Screen Shot 2021-04-29 at 8 08 55 AM](https://user-images.githubusercontent.com/1010384/116573983-27377600-a8c2-11eb-9998-0d08bfc6291d.png)


## Todos
- [x] Increase timeout for lambda.

## Review
- [ ] @Pocket/backend 