### PR TITLE
Add personalized topics ranker to topic lineup

### DIFF
--- a/app/json/slate_lineup_config.schema.json
+++ b/app/json/slate_lineup_config.schema.json
@@ -90,7 +90,8 @@
                   "pubspread",
                   "top15",
                   "top30",
-                  "thompson-sampling"
+                  "thompson-sampling",
+                  "personalized-topics"
                 ],
                 "title": "The Items Schema",
                 "default": "",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -372,7 +372,9 @@
     "experiments": [
       {
         "description": "default layout",
-        "rankers": [],
+        "rankers": [
+          "personalized-topics"
+        ],
         "slates": [
           "af2cc2c0-1286-47a3-b8ce-187b905f94af",
           "00f0c593-3c99-4d5a-9297-c66f8b00be01",

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -21,7 +21,8 @@ def get_all_rankers():
         top15,
         top30,
         thompson_sampling,
-        spread_publishers
+        spread_publishers,
+        personalize_topic_slates
     )
 
     return {
@@ -29,5 +30,6 @@ def get_all_rankers():
         'top15': top15,
         'top30': top30,
         'thompson-sampling': thompson_sampling,
+        'personalized-topics': personalize_topic_slates,
         'pubspread': spread_publishers
     }


### PR DESCRIPTION
# Goal

Enable the ranker that personalizes the order of slates in the topic lineup.

## Reference

Tickets:
* [BACK-801](https://getpocket.atlassian.net/browse/BACK-801)

Follow up from https://github.com/Pocket/recommendation-api/pull/264

## Implementation Decisions
