### PR TITLE
print->log so we get source info.

### DIFF
--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -1,6 +1,8 @@
 import aioboto3
 
 from asyncio import gather
+
+import logging
 from aws_xray_sdk.core import xray_recorder
 from boto3.dynamodb.conditions import Key
 from enum import Enum
@@ -128,6 +130,6 @@ class RecommendationModel(BaseModel):
             click_data = await ClickdataModel.get(slate_id, item_ids)
         except ValueError:
             rec_item_ids = ','.join(item_ids)
-            print(f'click data not found for candidates with item ids: {rec_item_ids}')
+            logging.warn(f'No click data found for {slate_id = } {rec_item_ids = }')
             click_data = {}
         return get_ranker('thompson-sampling')(recommendations, click_data)


### PR DESCRIPTION
I noticed a lot of these being logged in our cloudwatch logs, figured I would at least make them a logging statement to make them easier to track down.

Open question is what level issue this is. Some slates I wouldn't be surprised if we don't find clickdata (personalized stuff comes to mind), but for others it indicates an issue (e.g. editors picks). 