### PR TITLE
Change duplicate error to info

### DIFF
--- a/app/models/metrics/abstract_metrics_factory.py
+++ b/app/models/metrics/abstract_metrics_factory.py
@@ -121,7 +121,7 @@ class AbstractMetricsFactory(ABC):
                 #  now. If this error does not occur in practice, it would be better to change it to an exception.
                 # We're logging an error here because the full request context is available.
                 if not responses["Responses"][self._dynamodb_table]:
-                    logging.error(f"DynamoDB returned no metrics for query {request}")
+                    logging.info(f"DynamoDB returned no metrics for query {request}")
 
         return {k: metrics.get(k) for k in metrics_keys}
 


### PR DESCRIPTION
# Goal
Avoid confusion in Sentry caused by duplicate error messages. An error with almost exactly the same information is logged on line 51.

A secondary goal is to lower cost in Sentry by removing unnecessary errors.

## Reference

Slack thread:
* https://pocket.slack.com/archives/C01CKCB9746/p1627317161003700

Example Sentry errors:
* [Error from line 51](https://sentry.io/organizations/pocket/issues/2535109173/events/b2c9ecf42531491d89a48d76dc9566ed/?project=5503693)
* [Error from line 124](https://sentry.io/organizations/pocket/issues/2535109179/events/ea41a0976d034cc3ad3c509285605c5c/?project=5503693)

## Implementation Decisions
- There are situations where it's expected that a DynamoDB batch_get_item request returns no items, for example if the last chunk only contains 1 key, and that key is new. So it makes sense to turn this error into an info, and keep the error on line 51.