### PR TITLE
Create QA slates that are served to a QA user

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -58,6 +58,35 @@
     ]
   },
   {
+    "id": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1",
+    "displayName": "Editors' Picks",
+    "description": "QA slate duplicated from 2e3ddc90-8def-46d7-b85f-da7525c66fb1 that is only used for QA purposes",
+    "experiments": [
+      {
+        "description": "default",
+        "candidateSets": [
+          "493a5556-9800-449f-8f8c-c27bb6c8c810"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      },
+      {
+        "description": "ts15",
+        "candidateSets": [
+          "493a5556-9800-449f-8f8c-c27bb6c8c810"
+        ],
+        "rankers": [
+          "top15",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      }
+    ]
+  },
+  {
     "id": "48e766be-5e96-46fb-acbf-55fee3ae8a28",
     "displayName": "Editors' Picks",
     "description": "Top 5 curated items excluding syndicated that are at most a week old",
@@ -823,6 +852,35 @@
     ]
   },
   {
+    "id": "e8251442-ef97-422f-ad65-0f28e6f7a0d6",
+    "displayName": "QA slate duplicated from 0c09627b-a409-4768-b87d-7e1d29259785, that is only used for QA purposes",
+    "description": "Curated Personal Finance Slate",
+    "curatorTopicLabel": "Personal Finance",
+    "experiments": [
+      {
+        "description": "curated personal finance items",
+        "candidateSets": [
+          "5abdc94e-76d5-4f59-8e8d-22c8ee084a2d"
+        ],
+        "rankers": [
+          "top30",
+          "pubspread"
+        ]
+      },
+      {
+        "description": "curated personal finance items, thompson-sampling30",
+        "candidateSets": [
+          "5abdc94e-76d5-4f59-8e8d-22c8ee084a2d"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      }
+    ]
+  },
+  {
     "id": "f4b58337-4ab6-4563-9503-c384e773946f",
     "displayName": "Personal Finance",
     "description": "Curated Not New Tab Personal Finance Slate",
@@ -1318,6 +1376,23 @@
     "id": "0f322865-64e6-472d-8147-b3d6637a7d67",
     "displayName": "Our most-read Collections",
     "description": "Pocket Collections",
+    "experiments": [
+      {
+        "description": "All collections",
+        "candidateSets": [
+          "303174fc-a9ff-4a51-984a-e09ce7120d18"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b70d65c6-9171-40bf-bddb-5a60d42dd03f",
+    "displayName": "Our most-read Collections",
+    "description": "QA Slate duplicated from 0f322865-64e6-472d-8147-b3d6637a7d67 that is only used for QA purposes",
     "experiments": [
       {
         "description": "All collections",

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -21,6 +21,13 @@ class SlateModel(BaseModel):
     description: str = None
     recommendations: List[RecommendationModel] = None
 
+    __QA_USER_IDS = ['47372502']
+    __QA_SLATE_MAP = {
+        "2e3ddc90-8def-46d7-b85f-da7525c66fb1": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1",
+        "0c09627b-a409-4768-b87d-7e1d29259785": "e8251442-ef97-422f-ad65-0f28e6f7a0d6",
+        "0f322865-64e6-472d-8147-b3d6637a7d67": "b70d65c6-9171-40bf-bddb-5a60d42dd03f",
+    }
+
     @staticmethod
     @xray_recorder.capture_async('models_slate_get_slate')
     async def get_slate(slate_id: str, user_id: str = None, recommendation_count: Optional[int] = 10) -> 'SlateModel':
@@ -32,6 +39,16 @@ class SlateModel(BaseModel):
         :param recommendation_count: int, 0 = no recs, > 0 include this many recs
         :return: a SlateModel object
         """
+
+        """
+        HACK: For a particular set of QA users, change the slate to a QA slate.
+        This allows us to track the QA user's impression and open events through our engagement pipeline.
+        This code is intended to be temporary. A better long-term solution would be to use Unleash,
+        which is a feature flag service that supports putting specific users into an experiment branch.
+        """
+        if user_id in SlateModel.__QA_USER_IDS:
+            slate_id = SlateModel.__QA_SLATE_MAP.get(slate_id, slate_id)
+
         slate_config = SlateConfigModel.find_by_id(slate_id)
         return await SlateModel.__get_slate_from_slate_config(
             slate_config,


### PR DESCRIPTION
# Goal
We want to get some confidence that the engagement pipeline works end-to-end. The approach I'd like to take is to create QA slates for which we can control exactly how many impressions and opens it's gets, because only a particular QA user will see it. This will allow us to track this QA slate using its unique slate id through the engagement pipeline.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HOMPER-10

Documentation:
* https://docs.google.com/document/d/1AHAIdKrgDLPgUgUVoziqnX9vgnFyASBZQ595y3Oqvkk/edit#heading=h.o31clnk4jx7l

QA user details:
* https://pocket.slack.com/archives/C03QVL4SU/p1627576490339900

## Implementation Decisions
- This change is intended to be temporary. Once the end-to-end QA is complete, we can revert this change.
- A better long-term solution would be to use Unleash for deciding which branch of experiments users fall into. Unleash can put particular users into a particular branch. We originally decided not to include Unleash in recommendation-api because we didn't need most of its features. We should reevaluate whether that's still the case, but I'd prefer not to be blocked on that.