### PR TITLE
adding fallback slate lineup for web home

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -29,6 +29,35 @@
     ]
   },
   {
+    "id": "2389f563-bd42-411d-bca2-0966638053e8",
+    "displayName": "Editors' Picks",
+    "description": "Curated items that are over a week old without syndicated",
+    "experiments": [
+      {
+        "description": "default",
+        "candidateSets": [
+          "7e1f09b7-3e06-4723-a43c-7f6cd2f36749"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      },
+      {
+        "description": "ts15",
+        "candidateSets": [
+          "7e1f09b7-3e06-4723-a43c-7f6cd2f36749"
+        ],
+        "rankers": [
+          "top15",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      }
+    ]
+  },
+  {
     "id": "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
     "displayName": "Editors' Picks",
     "description": "Curated items excluding syndicated that are at most a week old",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -463,5 +463,54 @@
         ]
       }
     ]
+  },
+  {
+    "id": "05027beb-0053-4020-8bdc-4da2fcc0cb68",
+    "description": "Web Home - Personalized Curated",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [],
+        "slates": [
+          "631d8077-1462-4397-ad0a-aa340c27570a",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "2389f563-bd42-411d-bca2-0966638053e8",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d",
+          "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
+          "b4032752-155b-4f09-ac1e-f5337df19e88",
+          "b0de37c0-81ef-4063-a432-1bb64270b039",
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "4cc738f7-25a9-4511-9cc3-68a8f9be91f8",
+          "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
+          "90adee1c-7794-4f41-9645-2ff9cf91113c",
+          "0c09627b-a409-4768-b87d-7e1d29259785",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "b64c873e-7f05-496e-8be4-bfae929c8a04",
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "ea40bef5-4406-488d-ad9d-915dfa1f0794",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "249850f0-61c0-46f9-a16a-f0553c222800",
+    "description": "Web Home - Fallback Curated",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [],
+        "slates": [
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "2389f563-bd42-411d-bca2-0966638053e8",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
+          "90adee1c-7794-4f41-9645-2ff9cf91113c"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Goal

Create initial lineup and slates needed for initial web home experiments.

Lineups are outlined in [PRD](https://docs.google.com/document/d/10WkThCdi7AIeBbZkUOUqWwZ8WjiBwR3ugAb5hSw3z0A/edit?usp=sharing) and described in additional detail [here](https://getpocket.atlassian.net/l/c/ssRP4tfw)

[HOMEPER-24](https://getpocket.atlassian.net/browse/HOMPER-24)

## Implementation Decisions

For the fallback lineup for users that don't qualify for personalization I selected 

- three topic slates to be consistent with the personalized lineup and 
- picked them based on ~~total new tab CTR~~ consultation with editorial team

These choices should be reviewed with ~~editorial and~~ product.
