### PR TITLE
Serve QA slates for getSlateLineup

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -54,3 +54,15 @@ elasticache = {
 recit = {
     'endpoint_url': os.getenv('RECIT_ENDPOINT_URL', 'https://recit.readitlater.com')
 }
+
+# Slates will be replace for the following set of QA users. See qa_slate_maps below.
+qa_user_ids = ['47372502']
+# For QA users, slates in keys will be replaced by the slate in the corresponding value.
+qa_slate_map = {
+    # Editors' Picks -> QA duplicate of this slate
+    "2e3ddc90-8def-46d7-b85f-da7525c66fb1": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1",
+    # Curated Personal Finance Slate -> QA duplicate of this slate
+    "0c09627b-a409-4768-b87d-7e1d29259785": "e8251442-ef97-422f-ad65-0f28e6f7a0d6",
+    # Our most-read Collections -> QA duplicate of this slate
+    "0f322865-64e6-472d-8147-b3d6637a7d67": "b70d65c6-9171-40bf-bddb-5a60d42dd03f",
+}

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from app.models.recommendation import RecommendationModel
 from app.models.slate_config import SlateConfigModel
 from app.models.slate_experiment import SlateExperimentModel
+import app.config
 
 
 class SlateModel(BaseModel):
@@ -20,16 +21,6 @@ class SlateModel(BaseModel):
     display_name: str = None
     description: str = None
     recommendations: List[RecommendationModel] = None
-
-    __QA_USER_IDS = ['47372502']
-    __QA_SLATE_MAP = {
-        # Editors' Picks -> QA duplicate of this slate
-        "2e3ddc90-8def-46d7-b85f-da7525c66fb1": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1",
-        # Curated Personal Finance Slate -> QA duplicate of this slate
-        "0c09627b-a409-4768-b87d-7e1d29259785": "e8251442-ef97-422f-ad65-0f28e6f7a0d6",
-        # Our most-read Collections -> QA duplicate of this slate
-        "0f322865-64e6-472d-8147-b3d6637a7d67": "b70d65c6-9171-40bf-bddb-5a60d42dd03f",
-    }
 
     @staticmethod
     @xray_recorder.capture_async('models_slate_get_slate')
@@ -107,13 +98,13 @@ class SlateModel(BaseModel):
         recommendations = []
 
         """
-        HACK: For a particular set of QA users, change the slate to a QA slate.
+        HACK: For a particular set of QA users, change the slate to a QA slate if qa_slate_map has a replacement.
         This allows us to track the QA user's impression and open events through our engagement pipeline.
         This code is intended to be temporary. A better long-term solution would be to use Unleash,
         which is a feature flag service that supports putting specific users into an experiment branch.
         """
-        if user_id in SlateModel.__QA_USER_IDS and slate_config.id in SlateModel.__QA_SLATE_MAP:
-            slate_config = SlateConfigModel.find_by_id(SlateModel.__QA_SLATE_MAP[slate_config.id])
+        if user_id in app.config.qa_user_ids and slate_config.id in app.config.qa_slate_map:
+            slate_config = SlateConfigModel.find_by_id(app.config.qa_slate_map[slate_config.id])
 
         # If we have a > 0 recommendation count lets get some recommendations
         if recommendation_count > 0:

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -23,8 +23,11 @@ class SlateModel(BaseModel):
 
     __QA_USER_IDS = ['47372502']
     __QA_SLATE_MAP = {
+        # Editors' Picks -> QA duplicate of this slate
         "2e3ddc90-8def-46d7-b85f-da7525c66fb1": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1",
+        # Curated Personal Finance Slate -> QA duplicate of this slate
         "0c09627b-a409-4768-b87d-7e1d29259785": "e8251442-ef97-422f-ad65-0f28e6f7a0d6",
+        # Our most-read Collections -> QA duplicate of this slate
         "0f322865-64e6-472d-8147-b3d6637a7d67": "b70d65c6-9171-40bf-bddb-5a60d42dd03f",
     }
 
@@ -102,7 +105,6 @@ class SlateModel(BaseModel):
 
         experiment = None
         recommendations = []
-
 
         """
         HACK: For a particular set of QA users, change the slate to a QA slate.

--- a/app/models/slate.py
+++ b/app/models/slate.py
@@ -40,15 +40,6 @@ class SlateModel(BaseModel):
         :return: a SlateModel object
         """
 
-        """
-        HACK: For a particular set of QA users, change the slate to a QA slate.
-        This allows us to track the QA user's impression and open events through our engagement pipeline.
-        This code is intended to be temporary. A better long-term solution would be to use Unleash,
-        which is a feature flag service that supports putting specific users into an experiment branch.
-        """
-        if user_id in SlateModel.__QA_USER_IDS:
-            slate_id = SlateModel.__QA_SLATE_MAP.get(slate_id, slate_id)
-
         slate_config = SlateConfigModel.find_by_id(slate_id)
         return await SlateModel.__get_slate_from_slate_config(
             slate_config,
@@ -111,6 +102,16 @@ class SlateModel(BaseModel):
 
         experiment = None
         recommendations = []
+
+
+        """
+        HACK: For a particular set of QA users, change the slate to a QA slate.
+        This allows us to track the QA user's impression and open events through our engagement pipeline.
+        This code is intended to be temporary. A better long-term solution would be to use Unleash,
+        which is a feature flag service that supports putting specific users into an experiment branch.
+        """
+        if user_id in SlateModel.__QA_USER_IDS and slate_config.id in SlateModel.__QA_SLATE_MAP:
+            slate_config = SlateConfigModel.find_by_id(SlateModel.__QA_SLATE_MAP[slate_config.id])
 
         # If we have a > 0 recommendation count lets get some recommendations
         if recommendation_count > 0:

--- a/tests/functional/models/test_slate_lineup_model.py
+++ b/tests/functional/models/test_slate_lineup_model.py
@@ -2,6 +2,7 @@ from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
 from unittest.mock import patch
 
+import app.config
 from app.models.slate_lineup import SlateLineupModel
 from app.models.slate_config import SlateConfigModel
 from app.models.slate_experiment import SlateExperimentModel
@@ -63,6 +64,48 @@ class TestSlateLineupModel(TestDynamoDBBase):
         assert slate_lineup.slates[0].id == slate_config_id
         assert len(slate_lineup.requestId) == 36  # length of uuid4
         assert slate_lineup.slates[0].recommendations[0].item.item_id == '3208490410'
+
+    @patch('app.models.slate_lineup_config.SlateLineupConfigModel.find_by_id', return_value=slate_lineup_config_model)
+    @patch.object(SlateConfigModel, 'SLATE_CONFIGS_BY_ID', slate_configs_by_id)
+    @patch.object(app.config, 'qa_slate_map', {slate_config_id: slate_config_id_2})
+    async def test_get_slate_lineup_for_qa_user(self, slate_lineup_config):
+        self.candidateSetTable.put_item(Item={
+            "id": "test-candidate-id",
+            "version": 1,
+            "created_at": 1612907252,
+            "candidates": [
+                {
+                    "feed_id": 1,
+                    "item_id": 3208490410,
+                    "publisher": "hbr.org"
+                }
+            ]
+        })
+
+        self.candidateSetTable.put_item(Item={
+            "id": "test-candidate-id-2",
+            "version": 1,
+            "created_at": 1612907252,
+            "candidates": [
+                {
+                    "feed_id": 1,
+                    "item_id": 11,
+                    "publisher": "getpocket.com"
+                },
+                {
+                    "feed_id": 1,
+                    "item_id": 12,
+                    "publisher": "getpocket.com"
+                }
+            ]
+        })
+
+        qa_user_id = app.config.qa_user_ids[0]
+        slate_lineup = await SlateLineupModel.get_slate_lineup(slate_lineup_config_id, user_id=qa_user_id)
+
+        assert slate_lineup.id == slate_lineup_config_id
+        assert slate_lineup.slates[0].id == slate_config_id_2  # The slate is replace based on qa_slate_map.
+        assert slate_lineup.slates[0].recommendations[0].item.item_id == '11'
 
     @patch('app.models.slate_lineup_config.SlateLineupConfigModel.find_by_id', return_value=slate_lineup_config_model)
     @patch('app.models.slate_config.SlateConfigModel.find_by_id', return_value=slate_config_model)


### PR DESCRIPTION
# Goal
Fix https://github.com/Pocket/recommendation-api/pull/317, that only got applied to the getSlate operation. Clients are actually making a getSlateLineup request.

The end goal is still to get confidence that the engagement pipeline works end-to-end, by tracking a QA slate through the pipeline. By only serving this QA slate to a QA user, we can control exactly how many impressions and opens it gets.

## QA in Pocket-Dev
### QA user 47372502 receives QA slate 9dc26792-10ed-4fbe-a13d-6cce3a89b0a1
Request:
```shell
curl --location --request POST 'https://recommendation-api.getpocket.dev' \
--header 'userId: 47372502' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": "query QueryQA {\n getSlateLineup(slateLineupId: \"af3a5196-be16-4bf7-b131-70981e43b132\") {slates { id }\n }\n}",
    "variables": null,
    "operationName": "QueryQA"
}'
```
Response:
```
{
    "data": {
        "getSlateLineup": {
            "slates": [
                {
                    "id": "9dc26792-10ed-4fbe-a13d-6cce3a89b0a1"
                },
...
```
### Arbitrary user 1234 receives regular slate 2e3ddc90-8def-46d7-b85f-da7525c66fb1
Request:
```shell
curl --location --request POST 'https://recommendation-api.getpocket.dev' \
--header 'userId: 1234' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": "query QueryQA {\n getSlateLineup(slateLineupId: \"af3a5196-be16-4bf7-b131-70981e43b132\") {slates { id }\n }\n}",
    "variables": null,
    "operationName": "QueryQA"
}'
```
Response:
```
{
    "data": {
        "getSlateLineup": {
            "slates": [
                {
                    "id": "2e3ddc90-8def-46d7-b85f-da7525c66fb1"
                },
...
```


## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HOMPER-10

Documentation:
* https://docs.google.com/document/d/1AHAIdKrgDLPgUgUVoziqnX9vgnFyASBZQ595y3Oqvkk/edit#heading=h.o31clnk4jx7l

QA user details:
* https://pocket.slack.com/archives/C03QVL4SU/p1627576490339900

## Implementation Decisions
- Moved QA config to app.config such that tests can patch it.