### PR TITLE
Personalized webhome slate lineup

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -29,6 +29,35 @@
     ]
   },
   {
+    "id": "2389f563-bd42-411d-bca2-0966638053e8",
+    "displayName": "Editors' Picks",
+    "description": "Curated items that are over a week old without syndicated",
+    "experiments": [
+      {
+        "description": "default",
+        "candidateSets": [
+          "7e1f09b7-3e06-4723-a43c-7f6cd2f36749"
+        ],
+        "rankers": [
+          "top30",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      },
+      {
+        "description": "ts15",
+        "candidateSets": [
+          "7e1f09b7-3e06-4723-a43c-7f6cd2f36749"
+        ],
+        "rankers": [
+          "top15",
+          "thompson-sampling",
+          "pubspread"
+        ]
+      }
+    ]
+  },
+  {
     "id": "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
     "displayName": "Editors' Picks",
     "description": "Curated items excluding syndicated that are at most a week old",

--- a/app/json/slate_lineup_config.schema.json
+++ b/app/json/slate_lineup_config.schema.json
@@ -91,7 +91,8 @@
                   "top15",
                   "top30",
                   "thompson-sampling",
-                  "personalized-topics"
+                  "top1-topics",
+                  "top3-topics"
                 ],
                 "title": "The Items Schema",
                 "default": "",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -463,5 +463,54 @@
         ]
       }
     ]
+  },
+  {
+    "id": "05027beb-0053-4020-8bdc-4da2fcc0cb68",
+    "description": "Web Home - Personalized Curated",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [],
+        "slates": [
+          "631d8077-1462-4397-ad0a-aa340c27570a",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "2389f563-bd42-411d-bca2-0966638053e8",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d",
+          "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
+          "b4032752-155b-4f09-ac1e-f5337df19e88",
+          "b0de37c0-81ef-4063-a432-1bb64270b039",
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "4cc738f7-25a9-4511-9cc3-68a8f9be91f8",
+          "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
+          "90adee1c-7794-4f41-9645-2ff9cf91113c",
+          "0c09627b-a409-4768-b87d-7e1d29259785",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "b64c873e-7f05-496e-8be4-bfae929c8a04",
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "ea40bef5-4406-488d-ad9d-915dfa1f0794",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "249850f0-61c0-46f9-a16a-f0553c222800",
+    "description": "Web Home - Fallback Curated",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [],
+        "slates": [
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "2389f563-bd42-411d-bca2-0966638053e8",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
+          "90adee1c-7794-4f41-9645-2ff9cf91113c"
+        ]
+      }
+    ]
   }
 ]

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -23,7 +23,7 @@
       {
         "description": "default layout",
         "rankers": [
-          "personalized-topics"
+          "top1-topics"
         ],
         "slates": [
           "af2cc2c0-1286-47a3-b8ce-187b905f94af",
@@ -470,7 +470,7 @@
     "experiments": [
       {
         "description": "default layout",
-        "rankers": [],
+        "rankers": ["top3-topics"],
         "slates": [
           "631d8077-1462-4397-ad0a-aa340c27570a",
           "0f322865-64e6-472d-8147-b3d6637a7d67",

--- a/app/models/slate_lineup_config.py
+++ b/app/models/slate_lineup_config.py
@@ -3,7 +3,7 @@ import os
 
 from typing import Optional, List
 
-from app.config import JSON_DIR
+from app.config import JSON_DIR, dynamodb
 from app.json.utils import parse_to_dict
 from app.models.metrics.slate_metrics_factory import SlateMetricsFactory
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
@@ -123,9 +123,11 @@ class SlateLineupConfigModel:
             if ranker == 'thompson-sampling':
                 # thompson sampling requires slate metrics
                 ranker_kwargs = {
-                    'metrics': await SlateMetricsFactory().get(slate_lineup_id, [s.id for s in slate_configs])
+                    'metrics': await SlateMetricsFactory(dynamodb_endpoint=dynamodb["endpoint_url"]).get(
+                        slate_lineup_id,
+                        [s.id for s in slate_configs])
                 }
-            elif ranker == "personalized-topics":
+            elif ranker in {"top1-topics", "top3-topics"}:
                 ranker_kwargs = {
                     "personalized_topics": await PersonalizedTopicList.get(user_id)
                 }

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -23,7 +23,8 @@ def get_all_rankers():
         top45,
         thompson_sampling,
         spread_publishers,
-        personalize_topic_slates
+        top1_topics,
+        top3_topics
     )
 
     return {
@@ -32,6 +33,7 @@ def get_all_rankers():
         'top30': top30,
         'top45': top45,
         'thompson-sampling': thompson_sampling,
-        'personalized-topics': personalize_topic_slates,
+        'top1-topics': top1_topics,
+        'top3-topics': top3_topics,
         'pubspread': spread_publishers
     }

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -15,7 +15,7 @@ from app.models.personalized_topic_list import PersonalizedTopicList
 DEFAULT_ALPHA_PRIOR = 0.02
 DEFAULT_BETA_PRIOR = 1.0
 
-RankableListType = Union[List['SlateModel'], List['RecommendationModel']]
+RankableListType = Union[List['SlateConfigModel'], List['RecommendationModel']]
 RecommendationListType = List['RecommendationModel']
 
 
@@ -58,6 +58,29 @@ def top45(items: RankableListType) -> RankableListType:
     :return: first n recommendations from the list of recommendations
     """
     return items[:45]
+
+
+def top1_topics(slates: List['SlateConfigModel'], personalized_topics: PersonalizedTopicList) -> List['SlateConfigModel']:
+    """
+    returns the lineup with only the top
+    :param slates: initial list of slate configs
+    :param personalized_topics: recit response including sorted list of personalized topics
+    :return: list of slate configs with only the top topic slate
+    """
+
+    return __personalize_topic_slates(slates, personalized_topics, topic_limit=1)
+
+
+def top3_topics(slates: List['SlateConfigModel'], personalized_topics: PersonalizedTopicList) -> List[
+    'SlateConfigModel']:
+    """
+    returns the lineup with only the top
+    :param slates: initial list of slate configs
+    :param personalized_topics: recit response including sorted list of personalized topics
+    :return: list of slate configs with only the top 3 topic slate
+    """
+
+    return __personalize_topic_slates(slates, personalized_topics, topic_limit=3)
 
 
 def blocklist(recs: RecommendationListType, blocklist: Optional[List[str]] = None) -> RecommendationListType:
@@ -131,9 +154,9 @@ def thompson_sampling(
     return [x[0] for x in scores]
 
 
-def personalize_topic_slates(input_slate_configs: List['SlateConfigModel'],
-                             personalized_topics: PersonalizedTopicList,
-                             topic_limit: Optional[int] = 1) -> List['SlateConfigModel']:
+def __personalize_topic_slates(input_slate_configs: List['SlateConfigModel'],
+                               personalized_topics: PersonalizedTopicList,
+                               topic_limit: Optional[int] = 1) -> List['SlateConfigModel']:
     """
     This routine takes a list of slates as input in which must include slates with an associated curator topic
     label.  It uses the topic_profile that is supplied by RecIt to re-rank the slates according to affinity

--- a/tests/unit/rankers/test_algorithms.py
+++ b/tests/unit/rankers/test_algorithms.py
@@ -1,13 +1,18 @@
+import posixpath
 import unittest
 import os
 import json
 
 from app.models.metrics.metrics_model import MetricsModel
-from tests.unit.utils import generate_recommendations, generate_curated_configs, generate_uncurated_configs, generate_hybrid_configs
+from tests.unit.utils import generate_recommendations, generate_curated_configs, generate_uncurated_configs, generate_lineup_configs
 from app.config import ROOT_DIR
-from app.rankers.algorithms import spread_publishers, top5, top15, top30, thompson_sampling, blocklist, personalize_topic_slates
+from app.rankers.algorithms import spread_publishers, top5, top15, top30, thompson_sampling, blocklist, top1_topics, top3_topics
 from app.models.personalized_topic_list import PersonalizedTopicList, PersonalizedTopicElement
+from app.models.slate_lineup_config import SlateLineupConfigModel
 from operator import itemgetter
+
+ANDROID_DISCOVER_LINEUP_ID = "b50524d6-4df9-4f15-a0d0-13ccc8bdf4ed"
+WEB_HOME_LINEUP_ID = "05027beb-0053-4020-8bdc-4da2fcc0cb68"
 
 
 class TestAlgorithmsSpreadPublishers(unittest.TestCase):
@@ -288,42 +293,50 @@ class TestAlgorithmsPersonalizeTopics(unittest.TestCase):
                                for t in full_topic_profile.curator_topics
                                if t.curator_topic_label in input_topics]
 
-        for test_limit in [1, 3, 5]:
-            output_configs = personalize_topic_slates(input_configs, full_topic_profile, test_limit)
+        for test_limit, topic_ranker in zip([1, 3], [top1_topics, top3_topics]):
+            output_configs = topic_ranker(input_configs, full_topic_profile)
             ordered_output_topics = [c.curator_topic_label for c in output_configs]
             print(len(output_configs), test_limit)
             assert len(output_configs) == test_limit
             assert ordered_output_topics == personalized_topics[:test_limit]
 
-    def test_android_discover(self):
+    def test_hybrid_lineups(self):
         ''' this test is the case where one topic slate is returned from a
         lineup with a mix of curated and uncurated slates
         '''
         full_topic_profile = self._read_json_asset("recit_full_user_profile.json")
-        input_configs = generate_hybrid_configs()
-        input_topics = [c.curator_topic_label for c in input_configs]
-        # these are already sorted by RecIt
-        personalizable_slates = [t.curator_topic_label
-                                 for t in full_topic_profile.curator_topics
-                                 if t.curator_topic_label in input_topics]
-        other_slates = [t.id for t in input_configs
-                        if t.curator_topic_label not in personalizable_slates]
+        personalized_topics = [x.curator_topic_label for x in full_topic_profile.curator_topics]
 
-        for topic_limit in range(1, 9):
-            # one non-topic slate should be at start of lineup
-            output_configs = personalize_topic_slates(input_configs, full_topic_profile, topic_limit)
-            ordered_output_topics = [c.curator_topic_label for c in output_configs]
-            assert len(output_configs) == len(other_slates) + topic_limit
-            # first config is not personalziable and should be same as input
-            assert input_configs[0] == output_configs[0]
-            # returned topic slate should be highest ranked
-            assert ordered_output_topics[1:1+topic_limit] == personalizable_slates[:topic_limit]
-            # last two output slates are also not personalizable
-            assert input_configs[-2:] == output_configs[-2:]
+        for lineup_id in [ANDROID_DISCOVER_LINEUP_ID, WEB_HOME_LINEUP_ID]:
+            input_configs, description = generate_lineup_configs(lineup_id)
+            non_topic_slots = [i for i, c in enumerate(input_configs) if c.curator_topic_label is None]
+            # these are already sorted by RecIt
+            first_personalizable_slot = min(set(range(len(input_configs))).difference(set(non_topic_slots)))
+            other_slates_before = [t for i,t in enumerate(input_configs)
+                                   if t.curator_topic_label is None and i < first_personalizable_slot]
+            # this assumes topic slates are contiguous in lineup
+            other_slates_after = [t for i,t in enumerate(input_configs)
+                                  if t.curator_topic_label is None and i > first_personalizable_slot]
 
+            print("Testing: ", description)
+
+            for topic_limit, topic_ranker in zip([1, 3], [top1_topics, top3_topics]):
+                print(f"first personalizable lineup slot is {first_personalizable_slot}, topic limit is {topic_limit}")
+                # one non-topic slate should be at start of lineup
+                output_configs = topic_ranker(input_configs, full_topic_profile)
+                ordered_output_topics = [c.curator_topic_label for c in output_configs]
+
+                assert len(output_configs) == len(other_slates_before) + topic_limit + len(other_slates_after)
+                # if non-personalizable slates are first they should preserve their positions
+                assert output_configs[:len(other_slates_before)] == other_slates_before
+                # returned topic slates should be highest ranked
+                assert ordered_output_topics[first_personalizable_slot:first_personalizable_slot+topic_limit] == personalized_topics[:topic_limit]
+                # check any trailing slates that are also not personalizable
+                assert output_configs[(first_personalizable_slot + topic_limit):] == other_slates_after
 
     def test_no_topic_slates(self):
         full_topic_profile = self._read_json_asset("recit_full_user_profile.json")
         input_configs = generate_uncurated_configs()
 
-        self.assertRaises(ValueError, personalize_topic_slates, input_configs, full_topic_profile)
+        for topic_ranker in [top1_topics, top3_topics]:
+            self.assertRaises(ValueError, topic_ranker, input_configs, full_topic_profile)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -5,8 +5,7 @@ from app.models.item import ItemModel
 from app.models.slate_lineup_config import SlateLineupConfigModel
 from app.models.slate_config import SlateConfigModel
 
-WEB_HOME_LINEUP_ID = "55f5ed88-c7d9-48f9-bcf1-7ad214684ee9"
-
+ALL_CURATED_TOPICS_LINEUP = "55f5ed88-c7d9-48f9-bcf1-7ad214684ee9"
 
 def generate_recommendations(item_ids: List[int or str]) -> List[RecommendationModel]:
     recs = []
@@ -34,7 +33,7 @@ def generate_curated_configs() -> List[SlateConfigModel]:
     slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
     SlateLineupConfigModel.SLATE_LINEUP_CONFIGS_BY_ID = {lc.id: lc for lc in slate_lineup_configs}
 
-    input_lineup = SlateLineupConfigModel.SLATE_LINEUP_CONFIGS_BY_ID[WEB_HOME_LINEUP_ID]
+    input_lineup = SlateLineupConfigModel.SLATE_LINEUP_CONFIGS_BY_ID[ALL_CURATED_TOPICS_LINEUP]
     input_slates = input_lineup.experiments[0].slates
     input_configs = []
     for slate_id in input_slates:
@@ -51,11 +50,11 @@ def generate_uncurated_configs() -> List[SlateConfigModel]:
 
     return input_configs
 
-def generate_hybrid_configs() -> List[SlateConfigModel]:
+def generate_lineup_configs(lineup_id: str):
+    # get slate configs from lineup_id
+    slate_lineup_configs = SlateLineupConfigModel.load_slate_lineup_configs()
     slate_configs = SlateConfigModel.load_slate_configs()
-    # this config has editor's picks first without a topic label
-    # all curated topics and then two algorithmic topic slate configs
-    input_configs = [c for c in slate_configs if c.id == "2e3ddc90-8def-46d7-b85f-da7525c66fb1"]
-    input_configs += generate_curated_configs()
-    input_configs += generate_uncurated_configs()
-    return input_configs
+    x = [x for x in slate_lineup_configs if x.id == lineup_id]
+    slate_ids = x[0].experiments[0].slates
+    return [c for c in slate_configs if c.id in slate_ids], x[0].description
+


### PR DESCRIPTION
# Goal

Add a personalized lineup for the H2 web home work.  The details of the lineups are included [here](https://getpocket.atlassian.net/l/c/WsNaYxD4).  The goal of the work is to allow for lineups to have a mix of topic and non-topic slates and leave the non-topic slates as ordered, and remove the lower ranked topic slates after a cutoff.

## Reference

* [Details](https://getpocket.atlassian.net/l/c/WsNaYxD4)
* [HOMEPER-25](https://getpocket.atlassian.net/browse/HOMPER-25)
* [HOMEPER-23](https://getpocket.atlassian.net/browse/HOMPER-23)

## Implementation Decisions

We refactored the personalized topic slate ranker to comply with the `topN` style used for truncating candidate sets.  There is now a `top1_topics` ranker used for Android discover and a `top3_topics` ranker for web home.

I remain a little dissatisfied that we include all the topic slates in these lineups which is fine for now but won't scale if the set of topics grows.  
