### PR TITLE
Propose solution for graphql fallback behavior for personalized slates.

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -63,6 +63,7 @@ type Query {
 
     query getPersonalizedSlateLineup($id: String!) {
         getPersonalizedSlateLineup(id: $id) {
+            __typename
             personalizedSlateLineup {
                 ...SlateLineupParts
             }

--- a/schema.graphql
+++ b/schema.graphql
@@ -297,9 +297,14 @@ A requirement for personalization is missing. Use this slate linup instead.
 """
 type PersonalizedSlateLineupFallback {
     """
+    Why the fallback was used.
+    """
+    error: String!
+    
+    """
     The fallback slate lineup to be used when the personalized slate lineup is not available.
     """
-    fallbackSlateLineup: SlateLineup
+    fallbackSlateLineup: SlateLineup!
 }
 
 extend type Item @key(fields: "itemId") {

--- a/schema.graphql
+++ b/schema.graphql
@@ -38,6 +38,48 @@ type Query {
         "Maximum number of recommendations to return in {Slate.recommendations}, defaults to 10"
         recommendationCount: Int = 10
     ): SlateLineup
+
+
+    """
+    Request a specific personalized `SlateLineup` by id. This response allows for fallback behavior when there is not
+    a personalized slate lineup available.
+
+    Examples:
+
+    fragment SlateLineupParts on SlateLineup {
+        id
+        experimentId
+        slates {
+            recommendations {
+                id
+                item: {
+                    resolvedUrl
+                    title
+                    topImageUrl
+                }
+            }
+        }
+    }
+
+    query getPersonalizedSlateLineup($id: String!) {
+        getPersonalizedSlateLineup(id: $id) {
+            personalizedSlateLineup {
+                ...SlateLineupParts
+            }
+            fallbackSlateLineup {
+                ...SlateLineupParts
+            }
+        }
+    }
+    """
+    getPersonalizedSlateLineup(
+        "The {SlateLineup.id} of the SlateLineup to return"
+        slateLineupId: String!,
+        "Maximum number of slates to return in {SlateLineup.slates}, defaults to 8"
+        slateCount: Int = 8,
+        "Maximum number of recommendations to return in {Slate.recommendations}, defaults to 10"
+        recommendationCount: Int = 10
+    ): PersonalizedSlateLineup
 }
 
 """
@@ -232,6 +274,32 @@ type SlateLineup {
     An ordered list of slates for the client to display
     """
     slates: [Slate!]!
+}
+
+"""
+Wrap slate lineups to provide personalization fallback behavior. There are circumstances where we dont have a profile
+for a user. In this scenario we would like to optionally return a fallback slate lineup.
+"""
+union PersonalizedSlateLineup = PersonalizedSlateLineupSuccess | PersonalizedSlateLineupFallback
+
+"""
+All requirements for personalization are met and a personalized slate lineup was created.
+"""
+type PersonalizedSlateLineupSuccess {
+    """
+    The personalized slate. When there personlization requirements are not met this value can be null.
+    """
+    personalizedSlateLineup: SlateLineup!
+}
+
+"""
+A requirement for personalization is missing. Use this slate linup instead.
+"""
+type PersonalizedSlateLineupFallback {
+    """
+    The fallback slate lineup to be used when the personalized slate lineup is not available.
+    """
+    fallbackSlateLineup: SlateLineup
 }
 
 extend type Item @key(fields: "itemId") {


### PR DESCRIPTION
# Goal

Define a standard for fallback behavior when a personalized slate can not be generated.

## Todos
- [x] Document Graphql

## Review
- [ ] GraphqlExperts review @Pocket/backend 

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HOMPER-26

## Implementation Decisions

On the #p-user-profiles project we are adding some new behavior into the RecsAPI. The new behavior will be around querying personalized slates. What we want to do is to allow clients to request a personalized slate lineup and in the scenario where there is no user profile, for generating a slate lineup, we will return a nonpersonalized slate lineup as a fallback.  Where the simplest is to swap the slate lineup id on the response. However this would be an unexpected behavior as when a client requests a specific piece of content, we should return an error if that item doesn't exist. To satisfy this new requirement I am thinking that we should add something more explicit.