### PR TITLE
slatelineup for firefox android home recommendations

### DIFF
--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -513,5 +513,27 @@
         ]
       }
     ]
+  },
+  {
+    "id": "a26db39b-a68a-4e01-b680-443a466f9c36",
+    "description": "Firefox Android Home Recommendations",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [],
+        "slates": [
+          "0737b00e-a21e-4875-a4c7-3e14926d4acf",
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
+          "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "b64c873e-7f05-496e-8be4-bfae929c8a04",
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Goal

create a slatelineup for firefox android home recommendations. 

PRD:
* https://docs.google.com/document/d/1-P-Q15nHMGy_TQuwFh3YW07-dINXB5_rDMocwTuFl5s/edit#heading=h.jyahmgu05z6p (direct link to slates requested for this lineup)