### PR TITLE
[HOMEPER-23] - updating web home lineups

### DIFF
--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -473,8 +473,8 @@
         "rankers": [],
         "slates": [
           "631d8077-1462-4397-ad0a-aa340c27570a",
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
           "0f322865-64e6-472d-8147-b3d6637a7d67",
-          "2389f563-bd42-411d-bca2-0966638053e8",
           "2f2a3568-901f-4655-8735-daf67e8ecc5d",
           "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
           "b4032752-155b-4f09-ac1e-f5337df19e88",
@@ -503,12 +503,13 @@
         "description": "default layout",
         "rankers": [],
         "slates": [
+          "0737b00e-a21e-4875-a4c7-3e14926d4acf",
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
           "0f322865-64e6-472d-8147-b3d6637a7d67",
-          "2389f563-bd42-411d-bca2-0966638053e8",
           "2f2a3568-901f-4655-8735-daf67e8ecc5d",
-          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
           "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
-          "90adee1c-7794-4f41-9645-2ff9cf91113c"
+          "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca"
         ]
       }
     ]


### PR DESCRIPTION
# Goal

Update slate lineups for web home.  Changes here after discussions between Carolyn, Ian, and MattC:

- three fallback (unpersonalized) topic slates are [business](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#Curated-Business-Slate), [health](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#Curated-Health-Slate), and [entertainment](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#Curated-Entertainment-Slate)
- editor's pick slate for both lineups is [curated without syndicated](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#%5BinlineExtension%5DCurated-Live-No-Syndicated)
- stand in slate for unpersonalized lineup in place of personalized curated will be [curated live](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#%5BinlineExtension%5DCurated-Live)

These choices are likely to produce duplicate items across the fallback lineup's first two slates which are both based on the live new tab items.  Thus de-duping will need to be applied.

## Reference

[lineup doc](https://getpocket.atlassian.net/l/c/5Ct4AqJV)
[HOMEPER-6](https://getpocket.atlassian.net/browse/HOMPER-6)
[HOMEPER-23](https://getpocket.atlassian.net/browse/HOMPER-23)
[HOMEPER-24](https://getpocket.atlassian.net/browse/HOMPER-24)