### PR TITLE
Fix assertion that would fail randomly

### DIFF
--- a/tests/functional/models/test_slate_lineup_model.py
+++ b/tests/functional/models/test_slate_lineup_model.py
@@ -105,6 +105,7 @@ class TestSlateLineupModel(TestDynamoDBBase):
 
         assert slate_lineup.id == slate_lineup_config_id
         assert slate_lineup.slates[0].id == slate_config_id_2  # The slate is replace based on qa_slate_map.
+        # Assert sets of items ids is equal. Order is random because of Thompson-sampling.
         assert {'11', '12'} == {recommendation.item_id for recommendation in slate_lineup.slates[0].recommendations}
 
     @patch('app.models.slate_lineup_config.SlateLineupConfigModel.find_by_id', return_value=slate_lineup_config_model)
@@ -198,5 +199,7 @@ class TestSlateLineupModel(TestDynamoDBBase):
         assert len(slate_lineup.slates[0].recommendations) == 2
         assert len(slate_lineup.slates[1].recommendations) == 1
 
+        # Assert sets of items ids is equal. Order is random because of Thompson-sampling.
         assert {'10', '11'} == {recommendation.item_id for recommendation in slate_lineup.slates[0].recommendations}
+        # The items are deduplicated, so there is only one unique item left.
         assert slate_lineup.slates[1].recommendations[0].item_id == '12'

--- a/tests/functional/models/test_slate_lineup_model.py
+++ b/tests/functional/models/test_slate_lineup_model.py
@@ -105,7 +105,7 @@ class TestSlateLineupModel(TestDynamoDBBase):
 
         assert slate_lineup.id == slate_lineup_config_id
         assert slate_lineup.slates[0].id == slate_config_id_2  # The slate is replace based on qa_slate_map.
-        assert slate_lineup.slates[0].recommendations[0].item.item_id == '11'
+        assert {'11', '12'} == {recommendation.item_id for recommendation in slate_lineup.slates[0].recommendations}
 
     @patch('app.models.slate_lineup_config.SlateLineupConfigModel.find_by_id', return_value=slate_lineup_config_model)
     @patch('app.models.slate_config.SlateConfigModel.find_by_id', return_value=slate_config_model)


### PR DESCRIPTION
# Goal
Fix test that would fail 50% of time time, because the order of recommendations was determined using Thompson sampling.

## Review
Any ideas to prevent similar mistakes from happening in the future, beyond the comments that I added?

## Reference

CircleCI:
* https://app.circleci.com/pipelines/github/Pocket/recommendation-api/1511/workflows/a79d0370-c564-4b3d-8617-89a2a844f829/jobs/5841

## Implementation Decisions
