### PR TITLE
update single collection slates with new candidate set guids

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -1443,10 +1443,9 @@
       {
         "description": "10 incredible long reads collection",
         "candidateSets": [
-          "860ba820-9ef2-589b-bba8-a2b639e67cb6"
+          "adfdd1fd-28cb-5b2a-9d06-cdac7d949245"
         ],
         "rankers": [
-          "top30",
           "thompson-sampling"
         ]
       }
@@ -1460,10 +1459,9 @@
       {
         "description": "How to start cooking",
         "candidateSets": [
-          "d89008c0-730f-569c-95d8-6241d43317c3"
+          "243cac7e-fa75-5aa2-81d7-f7b40e942805"
         ],
         "rankers": [
-          "top30",
           "thompson-sampling"
         ]
       }


### PR DESCRIPTION
# Goal

The candidate set GUIDs associated with single collection slates were updated [here](https://github.com/Pocket/dl-metaflow-jobs/pull/54) to persist when collection slugs are revised.  The changes need to be reflected in the two current single collection slates exposed in the recommendation-api.  

## Reference

original sentry errors when slugs changed and candidate sets expired a month after collections-api went live:
https://pocket.slack.com/archives/CA3GZBXNG/p1628634663000700

[slate documentation](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2046197833/RecsAPI+Slate+Documentation#Single-Collection-Slates)

[metaflow PR](https://github.com/Pocket/dl-metaflow-jobs/pull/54)