### PR TITLE
Fetch the userId from the query itself rather than a header

### DIFF
--- a/app/graphql/graphql.py
+++ b/app/graphql/graphql.py
@@ -26,8 +26,9 @@ class Query(ObjectType):
                                                description="Number of recommendations to return, defaults to 10"))
     list_slates = Field(List(Slate), recommendation_count=Int(default_value=0,
                                                               description="Number of recommendations to return, defaults to 0"))
-    get_slate_lineup = Field(SlateLineup, slate_lineup_id=String(required=True,
-                                                                 description="SlateLineup id to get a specific slate lineup"),
+    get_slate_lineup = Field(SlateLineup,
+                             slate_lineup_id=String(required=True, description="SlateLineup id to get a specific slate lineup"),
+                             user_id=String(required=False, description="user id to get a personalized slate lineup"),
                              slate_count=Int(default_value=8, description="Number of slates to return, defaults to 8"),
                              recommendation_count=Int(default_value=10,
                                                       description="Maximum number of recommendations to return, defaults to 10"))
@@ -47,10 +48,12 @@ class Query(ObjectType):
     async def resolve_list_slates(self, info, recommendation_count: int) -> [SlateModel]:
         return await SlateModel.get_all(user_id=info.context.get('user_id'), recommendation_count=recommendation_count)
 
-    async def resolve_get_slate_lineup(self, info, slate_lineup_id: str, recommendation_count: int = 10,
+    async def resolve_get_slate_lineup(self, info, slate_lineup_id: str,
+                                       user_id: str = None,
+                                       recommendation_count: int = 10,
                                        slate_count: int = 8) -> SlateLineupModel:
         return await SlateLineupModel.get_slate_lineup(slate_lineup_id=slate_lineup_id,
-                                                       user_id=info.context.get('user_id'),
+                                                       user_id=user_id,
                                                        recommendation_count=recommendation_count,
                                                        slate_count=slate_count)
 

--- a/app/models/slate_lineup.py
+++ b/app/models/slate_lineup.py
@@ -14,13 +14,15 @@ class SlateLineupModel(BaseModel):
     Models a slate_lineup.
     """
     id: str
+    userId: Optional[str]
     requestId: str = None
     experimentId: str = None
     slates: List[SlateModel]
 
     @staticmethod
     @xray_recorder.capture_async('models_slate_lineup_get_slate_lineup')
-    async def get_slate_lineup(slate_lineup_id: str, user_id: Optional[str] = None,
+    async def get_slate_lineup(slate_lineup_id: str,
+                               user_id: Optional[str] = None,
                                recommendation_count: Optional[int] = 10,
                                slate_count: Optional[int] = 8) -> 'SlateLineupModel':
         """
@@ -38,10 +40,14 @@ class SlateLineupModel(BaseModel):
                                                                      user_id=user_id,
                                                                      recommendation_count=recommendation_count,
                                                                      slate_count=slate_count)
-
+        if user_id:
+            proving_user_id_query_param_concept = "experiment-for-personalized-slate-lineup"
+        else:
+            proving_user_id_query_param_concept = experiment.id
+            
         return SlateLineupModel(
             id=slate_lineup_id,
-            experimentId=experiment.id,
+            experimentId=proving_user_id_query_param_concept,
             slates=slates,
             requestId=str(uuid.uuid4()),
         )

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,7 +5,7 @@ type Query {
     getTopicRecommendations(slug: String!, algorithmicCount: Int = 20, curatedCount: Int = 5): TopicRecommendations  @deprecated(reason: "Use `getSlateLineup` with a specific SlateLineup instead.")
 
     """
-    List all available topics that we have recomendarions for.
+    List all available topics that we have recomendations for.
     """
     listTopics: [Topic!]! @deprecated(reason: "Use `getSlateLineup` with a specific SlateLineup instead.")
 
@@ -33,6 +33,8 @@ type Query {
     getSlateLineup(
         "The {SlateLineup.id} of the SlateLineup to return"
         slateLineupId: String!,
+        "Optional userId to personalize the lineup"
+        userId: String,
         "Maximum number of slates to return in {SlateLineup.slates}, defaults to 8"
         slateCount: Int = 8,
         "Maximum number of recommendations to return in {Slate.recommendations}, defaults to 10"


### PR DESCRIPTION
# Context

It looks like we expect personalized slate lineup requests to include the user_id as a header that we resolve at the middleware level, rather than as part of the GQL query itself.

## Question
How did we decide on that approach? 

## Proposal

I'm picturing an alternative in which the client includes the userId in the query as a parameter—just like slateLineupId, except optional. This is more graph queuelly, but the functional advantages would be:

- One centralized location for visualizing the passage of information about the expected result to the Recs API
- We can use Apollo client to make personalized queries, rather than having to shell out to Postman and use a RESTified version of the query to run it, which is what we are doing now.

This PR makes the change, so it wouldn't create extra work for anyone to implement. But before I do, I'd love to know:

1. If I've overlooked a requirement that influenced us to do it the way it's currently done
2. How many places we'll have to change clients if we change this API