### PR TITLE
Fetch more items from RecIt, make top-n rankers warn about insufficient items

### DIFF
--- a/app/models/candidate_set.py
+++ b/app/models/candidate_set.py
@@ -32,7 +32,7 @@ RECIT_PREFIX = "recit-personalized"
 
 # The keys represent valid names for use in RecsAPI, the corresponding values are the module names for RecIt.
 RECIT_MODULES = {'bestof': 'recsapi_bestof', 'syndicated': 'recsapi_syndicated', 'curated': 'recsapi_curated'}
-RECIT_LIMIT = 15
+RECIT_LIMIT = 60
 
 
 class RecItCandidateSet(CandidateSetModel):

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -1,3 +1,4 @@
+from functools import partial
 import logging
 import json
 
@@ -19,45 +20,24 @@ RankableListType = Union[List['SlateConfigModel'], List['RecommendationModel']]
 RecommendationListType = List['RecommendationModel']
 
 
-def top5(items: RankableListType) -> RankableListType:
+def top_n(n: int, items: RankableListType) -> RankableListType:
     """
-    Gets the first 5 recommendations from the list of recommendations.
+    Gets the first n recommendations from the list of recommendations.
 
     :param items: a list of recommendations in the desired order (pre-publisher spread)
-    :return: first 5 recommendations from the list of recommendations
-    """
-    return items[:5]
-
-
-def top15(items: RankableListType) -> RankableListType:
-    """
-    Gets the first 15 recommendations from the list of recommendations.
-
-    :param items: a list of recommendations in the desired order (pre-publisher spread)
-    :return: first 15 recommendations from the list of recommendations
-    """
-    return items[:15]
-
-
-def top30(items: RankableListType) -> RankableListType:
-    """
-    Gets the first 30 recommendations from the list of recommendations.
-
-    :param items: a list of recommendations in the desired order (pre-publisher spread)
-    :return: first 30 recommendations from the list of recommendations
-    """
-    return items[:30]
-
-
-def top45(items: RankableListType) -> RankableListType:
-    """
-    Gets the first N recommendations from the list of recommendations.
-
-    :param items: a list of recommendations in the desired order (pre-publisher spread)
-    :param n: int, number of recommendations to be returned
+    :param n: The number of items to return
     :return: first n recommendations from the list of recommendations
     """
-    return items[:45]
+    if len(items) <= n:
+        logging.warning(f"less items than n: {len(items) =} <= {n =} ")
+
+    return items[:n]
+
+
+top5 = partial(top_n, 5)
+top15 = partial(top_n, 15)
+top30 = partial(top_n, 30)
+top45 = partial(top_n, 45)
 
 
 def top1_topics(slates: List['SlateConfigModel'], personalized_topics: PersonalizedTopicList) -> List['SlateConfigModel']:


### PR DESCRIPTION
The warning might end up being way too noisy, so I can be convinced to turn that down to an info or debug, but we've had several times now where we intended to get more items from a CandidateSet than we did, and it has caused issues. 

Long term, we probably need an entire configuration to represent how many items are expected at each stage. I did this in RecIt by having rankers explicitly note the min items they expect. We will probably need to have CandidateSets support limits to allow for us to express the idea that we want a specific number of items at each stage of the pipeline.