### PR TITLE
Decrease false-positive alarms for SQS Lambda

### DIFF
--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -72,8 +72,9 @@ export class SqsLambda extends Resource {
             treatMissingData: 'breaching'
           },
           errors: {
-            period: 10800, // 3 hours
-            threshold: 2,
+            evaluationPeriods: 3,
+            period: 3600, // 1 hour
+            threshold: 20,
             actions: [pagerDuty.snsNonCriticalAlarmTopic.arn]
           }
         }


### PR DESCRIPTION
# Goal
Decrease false-positive alarms for Lambda. This alarm was active for several months without 

## Reference

Slack thread:
* https://pocket.slack.com/archives/C016NAMSW2J/p1629407675020500

## Implementation Decisions
- I increased the threshold to 20, well above the normal level.
- I decreased the period and increased the evaluationPeriods, to prevent a single spike from triggering the alarm, as occurred on Aug 6th.

![Screenshot from 2021-08-19 14-37-00](https://user-images.githubusercontent.com/1547251/130149335-0c01c965-269e-4004-b02e-2f861a0ab6f4.png)
