### PR TITLE
Update util.py to print more like `tree`

### DIFF
--- a/app/json/utils.py
+++ b/app/json/utils.py
@@ -35,25 +35,67 @@ def guid_unique(config_dict, guid_attr="id"):
 
 if __name__ == "__main__":
     from collections import Counter
-    print("Validating layout_configs.json")
+    import hashlib
+    import argparse
+    parser = argparse.ArgumentParser(description="Validate and visualize the RecsAPI configuration")
+    parser.add_argument('--full-guids', help="Show full guids rather than the first 7 characters", action='store_true')
+    parser.add_argument('--lineup', help="Only show lineups that start with these characters", default=None, type=str)
+    args = parser.parse_args()
+
     layouts = parse_to_dict("slate_lineup_configs.json", "slate_lineup_config.schema.json")
     guid_unique(layouts)
 
-    print("Validating slate_config.json")
     slates = parse_to_dict("slate_configs.json", "slate_config.schema.json")
     guid_unique(slates)
 
+    if args.full_guids:
+        # Print all of the GUID
+        guid_len = None
+    else:
+        # Only print this much of the GUID, reduces visual clutter
+        guid_len = 7
 
+    PIPE = "│"
+    ELBOW = "└──"
+    TEE = "├──"
+    PIPE_PREFIX = "│   "
+    SPACE_PREFIX = "    "
+
+    def get_pipes(idx, col):
+        """Returns the appropriate prefix and connector based on the current `idx` for `col`."""
+        if idx + 1 == len(col):
+            return SPACE_PREFIX, ELBOW
+        else:
+            return PIPE_PREFIX, TEE
+
+    def generate_exp_hash(experiment_dict):
+        """Code taken from `models/experiment.py` to generate hashes here"""
+        return hashlib.sha1(
+            json.dumps(experiment_dict, sort_keys=True).encode()
+        ).hexdigest()
+
+    PREFIXES = [SPACE_PREFIX] * 3
     slates = {r['id']: r for r in slates}
     for layout in layouts:
-        print(f"Lineup: {layout['id']} {layout['description']}")
-        for experiment in layout['experiments']:
-            print(f"- Experiment: {experiment['description']}")
-            for slate_id in experiment['slates']:
-                print(f"-- Slate: {slate_id} {slates[slate_id]['displayName']}")
-                for slate_experiment in slates[slate_id]["experiments"]:
-                    print(f"--- Experiment: {slate_experiment['description']}")
-                    for candidate_set in slate_experiment['candidateSets']:
-                        print(f"---- Candidate Set: {candidate_set}")
+        if args.lineup and not layout['id'].startswith(args.lineup):
+            continue
+        print(f"[{layout['id'][:guid_len]}] {layout['description']}")
+        for idx, experiment in enumerate(layout['experiments']):
+            s, p = get_pipes(idx, layout['experiments'])
+            PREFIXES[0] = s
+            exp_hash = generate_exp_hash(experiment)
+            print(f"{p} [{exp_hash[:guid_len]}] Experiment: {experiment['description']}")
+            for idx, slate_id in enumerate(experiment['slates']):
+                s, p = get_pipes(idx, experiment['slates'])
+                PREFIXES[1] = s
+                print(f"{''.join(PREFIXES[:1])}{p} [{slate_id[:guid_len]}] Slate:  {slates[slate_id]['displayName']}")
+                for idx, slate_experiment in enumerate(slates[slate_id]["experiments"]):
+                    s,p = get_pipes(idx, slates[slate_id]['experiments'])
+                    PREFIXES[2] = s
+                    exp_hash = generate_exp_hash(slate_experiment)
+                    print(f"{''.join(PREFIXES[:2])}{p} [{exp_hash[:guid_len]}] Experiment: {slate_experiment['description']}")
+                    for idx, candidate_set in enumerate(slate_experiment['candidateSets']):
+                        s, p = get_pipes(idx, slate_experiment['candidateSets'])
+                        print(f"{''.join(PREFIXES[:3])}{p} [{candidate_set[:guid_len]}] Candidate Set")
         print()
 


### PR DESCRIPTION
Update util to make the printing easier to read. Also includes experiment hashes now, and allows you to limit which lineups are shown.
```
iwsmith@vulcan json % python utils.py --lineup 55
[55f5ed8] Web Home - Curated Topic Slates Not Live on New Tab
└── [2bd35d5] Experiment: default layout
    ├── [af2cc2c] Slate:  Business
    │   └── [817f4b2] Experiment: curated not new tab business items
    │       └── [962a8ef] Candidate Set
    ├── [00f0c59] Slate:  Career
    │   └── [3069faf] Experiment: curated not new tab career items
    │       └── [651990d] Candidate Set
    ├── [856eb5f] Slate:  Education
    │   └── [8265cfe] Experiment: curated not new tab education items
    │       └── [3a5f2bf] Candidate Set
    ├── [cceefa2] Slate:  Entertainment
    │   └── [665f73b] Experiment: curated not new tab entertainment items
    │       └── [e53ae7b] Candidate Set
```