### PR TITLE
Android Personalization V2

### DIFF
--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -67,6 +67,23 @@
     ]
   },
   {
+    "id": "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1",
+    "description": "iOS Discover Tab",
+    "experiments": [
+      {
+        "description": "Initial layout",
+        "rankers": [],
+        "slates": [
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
+          "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d"
+        ]
+      }
+    ]
+  },
+  {
     "id": "2a817ad0-cbba-4330-9559-291468145588",
     "description": "Web Home Test #1",
     "experiments": [

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -17,6 +17,23 @@
     ]
   },
   {
+    "id": "20481076-2261-4916-801a-fd186986367b",
+    "description": "Android Discover Tab Personalized Curated",
+    "experiments": [
+      {
+        "description": "Initial layout",
+        "rankers": [],
+        "slates": [
+          "631d8077-1462-4397-ad0a-aa340c27570a",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
+          "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d"
+        ]
+      }
+    ]
+  },
+  {
     "id": "e0c0cf7e-3a02-4a2f-a614-5a0cad4e3273",
     "description": "Android Discover Tab Personalized Algorithmic Topic",
     "experiments": [

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -1,13 +1,46 @@
 [
   {
-    "id": "20481076-2261-4916-801a-fd186986367b",
-    "description": "Android Discover Tab Personalized Curated",
+    "id": "aaf47c0f-1361-4c8c-a89f-fa45e1dc2978",
+    "description": "Android Discover Tab Personalizedv2 Curated",
     "experiments": [
       {
         "description": "Initial layout",
         "rankers": [],
         "slates": [
           "631d8077-1462-4397-ad0a-aa340c27570a",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
+          "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e0c0cf7e-3a02-4a2f-a614-5a0cad4e3273",
+    "description": "Android Discover Tab Personalized Algorithmic Topic",
+    "experiments": [
+      {
+        "description": "default layout",
+        "rankers": [
+          "top1-topics"
+        ],
+        "slates": [
+          "d9c6ddfa-a58d-402d-9664-4190ba197ea6",
+          "e6c8db8d-cae7-4947-a57e-872dec639472",
+          "8aaac382-9c27-42ab-9470-ac1dfc666262",
+          "ce96db55-f32e-48f1-929f-216eb2e8c082",
+          "884414d5-502d-4e1a-8e70-1dc8eb4a345a",
+          "44dff273-3604-40e9-a0b5-bf3852581990",
+          "494eaa68-f048-4f52-bb9a-5e7d2526f5cb",
+          "e6600ffe-b65a-42d3-b570-f460f3d7326e",
+          "72ce0827-9dbc-470f-9722-39476daaeb0f",
+          "9901851d-ea76-4667-8dc7-0c1677ecb910",
+          "ab6048ca-5c61-4e87-aefd-7a612b60ab7b",
+          "8a495385-9972-4d0e-b93e-4234f4897939",
+          "fa61096a-b681-4251-b299-2fda06c49ebf",
+          "47688fcf-2bbb-4e0e-a02e-1f68c248a67e",
+          "d024ce9c-ed96-453f-a81e-8a0b850681e7",
           "0f322865-64e6-472d-8147-b3d6637a7d67",
           "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
           "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",
@@ -41,6 +74,23 @@
           "e6c00454-4a00-47c1-8f22-906122c261ed",
           "ed9604ce-b752-48bd-b8c5-3a8cf6b54ced",
           "4345efa7-2c89-4884-b836-3260757a3a97",
+          "0f322865-64e6-472d-8147-b3d6637a7d67",
+          "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
+          "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",
+          "2f2a3568-901f-4655-8735-daf67e8ecc5d"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f3c65847-5a0b-416d-8b14-4ca37bc08f4d",
+    "description": "Android Discover Tab Experiment Control",
+    "experiments": [
+      {
+        "description": "Initial layout",
+        "rankers": [],
+        "slates": [
+          "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
           "0f322865-64e6-472d-8147-b3d6637a7d67",
           "626397d3-fa4e-4299-8d07-cbeaa269ebc1",
           "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6",


### PR DESCRIPTION
This enables three new slates in support of an Android PersonalizationV2 experiment:
*control* - We are using a different Lineup ID so I can easily differentiate users in experiment from those not in experiment

*personalized_curated* - A new personalization algorithm that generates more diverse recommendations, only recommends items that went live in the last 52 weeks, and generates more items to decrease the amount of repeats users see.

*personalized_topic* - Selects a single topic to show the user based on their profile, but this time shows them an algorithmic topic slate instead of a curated one.

See https://docs.google.com/document/d/1PSjmTiBWIn_tuweoc5kaAVlsEqgv29ujMFoHVUaU0is/edit#