### PR TITLE
Auth with Docker for XRay image

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -220,6 +220,7 @@ class RecommendationAPI extends TerraformStack {
                 {
                     name: 'xray-daemon',
                     containerImage: 'amazon/aws-xray-daemon',
+                    repositoryCredentialsParam: `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:Shared/DockerHub`,
                     portMappings: [
                         {
                             hostPort: 2000,


### PR DESCRIPTION
# Goal
Fix error during deployment caused by a Dockerhub rate limit:
> CannotPullContainerError: inspect image has been retried 5 time(s): httpReaderSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/amazon/aws-xray-daemon/manifests/sha256:5bf715bbe434ebf892b66bba54ce04db47b2914f23a949410d8029fbbf...