### PR TITLE
Add rank-topics ranker, change Web to use it, add all topics

### DIFF
--- a/app/json/slate_lineup_config.schema.json
+++ b/app/json/slate_lineup_config.schema.json
@@ -92,7 +92,8 @@
                   "top30",
                   "thompson-sampling",
                   "top1-topics",
-                  "top3-topics"
+                  "top3-topics",
+                  "rank-topics"
                 ],
                 "title": "The Items Schema",
                 "default": "",

--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -554,7 +554,7 @@
     "experiments": [
       {
         "description": "default layout",
-        "rankers": ["top3-topics"],
+        "rankers": ["rank-topics"],
         "slates": [
           "631d8077-1462-4397-ad0a-aa340c27570a",
           "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
@@ -593,7 +593,19 @@
           "2f2a3568-901f-4655-8735-daf67e8ecc5d",
           "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
           "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
-          "e9df8a81-19af-48e2-a90f-05e9a37491ca"
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
+          "b4032752-155b-4f09-ac1e-f5337df19e88",
+          "b0de37c0-81ef-4063-a432-1bb64270b039",
+          "1a634351-361b-4115-a9d5-b79131b1f95a",
+          "4cc738f7-25a9-4511-9cc3-68a8f9be91f8",
+          "90adee1c-7794-4f41-9645-2ff9cf91113c",
+          "0c09627b-a409-4768-b87d-7e1d29259785",
+          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
+          "b64c873e-7f05-496e-8be4-bfae929c8a04",
+          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
+          "ea40bef5-4406-488d-ad9d-915dfa1f0794",
+          "e0d7063a-9421-4148-b548-446e9fbc8566",
+          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
         ]
       }
     ]

--- a/app/models/slate_config.py
+++ b/app/models/slate_config.py
@@ -111,6 +111,9 @@ class SlateConfigModel:
 
         return slate_config
 
+    def __repr__(self):
+        return f"<SlateConfigModel {self.displayName} [{self.id}] >"
+
 
 def validate_slate_config(slate_configs: List[SlateConfigModel]) -> None:
     """

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -24,7 +24,8 @@ def get_all_rankers():
         thompson_sampling,
         spread_publishers,
         top1_topics,
-        top3_topics
+        top3_topics,
+        rank_topics
     )
 
     return {
@@ -35,5 +36,6 @@ def get_all_rankers():
         'thompson-sampling': thompson_sampling,
         'top1-topics': top1_topics,
         'top3-topics': top3_topics,
+        'rank-topics': rank_topics,
         'pubspread': spread_publishers
     }

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -39,6 +39,15 @@ top15 = partial(top_n, 15)
 top30 = partial(top_n, 30)
 top45 = partial(top_n, 45)
 
+def rank_topics(slates: List['SlateConfigModel'], personalized_topics: PersonalizedTopicList) -> List['SlateConfigModel']:
+    """
+    returns the lineup with topic slates sorted by the user's profile.
+    :param slates: initial list of slate configs
+    :param personalized_topics: recit response including sorted list of personalized topics
+    :return: list of slate configs the personalized topics sorted
+    """
+
+    return __personalize_topic_slates(slates, personalized_topics, topic_limit=None)
 
 def top1_topics(slates: List['SlateConfigModel'], personalized_topics: PersonalizedTopicList) -> List['SlateConfigModel']:
     """
@@ -170,10 +179,15 @@ def __personalize_topic_slates(input_slate_configs: List['SlateConfigModel'],
     for config in input_slate_configs:
         if config in personalizable_configs:
             # if slate is personalizable add highest ranked slate remaining
-            if added_topic_slates < topic_limit:
+            if topic_limit:
+                if added_topic_slates < topic_limit:
+                    output_configs.append(personalizable_configs[personalized_index])
+                    added_topic_slates += 1
+                    personalized_index += 1
+            else:
                 output_configs.append(personalizable_configs[personalized_index])
-                added_topic_slates += 1
                 personalized_index += 1
+                added_topic_slates += 1
         else:
             logging.debug(f"adding topic slate {added_topic_slates}")
             output_configs.append(config)


### PR DESCRIPTION
1. Add `rank-topics`, which just re-ranks the topics based on a user profile
2. Updated the Web SlateLineup to use it for the Web Home Personalization experiment
3. Update the Web Home Personalized and Web Home Unpersonalized SlateLineups to return *all* topics. This will allow for filtering to relevant topics on the client. This may cause performance issue, but since the topics are all fairly static the hope is everything is sufficiently cached.