### PR TITLE
Register personalized ranker in a second location, remove Thompson-Sampling from collections

### DIFF
--- a/app/json/slate_configs.json
+++ b/app/json/slate_configs.json
@@ -1435,8 +1435,7 @@
           "303174fc-a9ff-4a51-984a-e09ce7120d18"
         ],
         "rankers": [
-          "top30",
-          "thompson-sampling"
+          "top30"
         ]
       }
     ]

--- a/app/models/slate_lineup_config.py
+++ b/app/models/slate_lineup_config.py
@@ -8,7 +8,7 @@ from app.json.utils import parse_to_dict
 from app.models.metrics.slate_metrics_factory import SlateMetricsFactory
 from app.models.slate_lineup_experiment import SlateLineupExperimentModel
 from app.models.slate_config import SlateConfigModel
-from app.rankers import get_ranker
+from app.rankers import get_ranker, PERSONALIZED_RANKERS
 from app.models.personalized_topic_list import PersonalizedTopicList
 
 
@@ -127,7 +127,7 @@ class SlateLineupConfigModel:
                         slate_lineup_id,
                         [s.id for s in slate_configs])
                 }
-            elif ranker in {"top1-topics", "top3-topics"}:
+            elif ranker in PERSONALIZED_RANKERS:
                 ranker_kwargs = {
                     "personalized_topics": await PersonalizedTopicList.get(user_id)
                 }

--- a/app/rankers/__init__.py
+++ b/app/rankers/__init__.py
@@ -1,6 +1,7 @@
 def get_ranker(name):
     return get_all_rankers()[name]
 
+PERSONALIZED_RANKERS = {"top1-topics", "top3-topics", "rank-topics"}
 
 def get_all_rankers():
     # Importing algorithms within the function here ensures that when rankers are imported


### PR DESCRIPTION
I missed a location for adding a personalized ranker (see the below sentry error). I centralized this in `rankers/__init__.py` so this doesn't happen again.
https://sentry.io/organizations/pocket/issues/2680882333/?project=5503693&query=is%3Aunresolved

Also remove Thomspson-Sampling from collections, which is unrelated but is necessary to fix collections we think.