### PR TITLE
Web Home Personalized top3 topics, only return 3 topics for unpersonalized

### DIFF
--- a/app/json/slate_lineup_configs.json
+++ b/app/json/slate_lineup_configs.json
@@ -554,7 +554,7 @@
     "experiments": [
       {
         "description": "default layout",
-        "rankers": ["rank-topics"],
+        "rankers": ["top3-topics"],
         "slates": [
           "631d8077-1462-4397-ad0a-aa340c27570a",
           "2e3ddc90-8def-46d7-b85f-da7525c66fb1",
@@ -593,19 +593,7 @@
           "2f2a3568-901f-4655-8735-daf67e8ecc5d",
           "505c0126-d54d-42ef-8fe7-0f6a6f24e3a5",
           "7cb4f497-fd05-42c5-9f78-3650e9ddba21",
-          "e9df8a81-19af-48e2-a90f-05e9a37491ca",
-          "b4032752-155b-4f09-ac1e-f5337df19e88",
-          "b0de37c0-81ef-4063-a432-1bb64270b039",
-          "1a634351-361b-4115-a9d5-b79131b1f95a",
-          "4cc738f7-25a9-4511-9cc3-68a8f9be91f8",
-          "90adee1c-7794-4f41-9645-2ff9cf91113c",
-          "0c09627b-a409-4768-b87d-7e1d29259785",
-          "9bece73b-4d54-43a6-bb10-d7b02abcd181",
-          "b64c873e-7f05-496e-8be4-bfae929c8a04",
-          "6d1273a5-055e-4de0-8a5b-5f2b79d37e5c",
-          "ea40bef5-4406-488d-ad9d-915dfa1f0794",
-          "e0d7063a-9421-4148-b548-446e9fbc8566",
-          "9389d944-fdcf-4394-9ca3-4604c0af4fac"
+          "e9df8a81-19af-48e2-a90f-05e9a37491ca"
         ]
       }
     ]


### PR DESCRIPTION
Basically resets to what we had a few days ago. Pulling all the topic slates is too slow and we aren't able to address that right now.