### PR TITLE
Downgrade Uvicorn to 0.14.0 to fix xray errors

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ sentry-sdk = "*"
 graphene-pydantic = "==0.1.0"
 aioboto3 = "<9"
 gunicorn = "*"
-uvicorn = "==0.15.0"
+uvicorn = "==0.14.0"
 # Locking fastapi to prevent a conflict with pydantic:
 #   pydantic<2.0.0,>=1.6.2 (from fastapi==0.65.1)
 #   pydantic<=1.6,>=1.0 (from graphene-pydantic==0.1.0)

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "952e2b6d285131ae75d1600e21244c2ef0f7a12f76f51cbb3c88a81d07b53ae4"
+            "sha256": "e81b48286cb9098527fbd963658a6e32d825d5d2d1abe5b1c7a1f53677b3a06e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -757,11 +757,11 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:17f898c64c71a2640514d4089da2689e5db1ce5d4086c2d53699bf99513421c1",
-                "sha256:d9a3c0dd1ca86728d3e235182683b4cf94cd53a867c288eaeca80ee781b2caff"
+                "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae",
+                "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"
             ],
             "index": "pypi",
-            "version": "==0.15.0"
+            "version": "==0.14.0"
         },
         "uvloop": {
             "hashes": [
@@ -1394,11 +1394,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pyparsing": {
             "hashes": [


### PR DESCRIPTION
# Goal
Undo automatic upgrade from https://github.com/Pocket/recommendation-api/pull/430. This was causing high error volume in Sentry. See https://github.com/Pocket/recommendation-api/pull/416.

# References
Sentry error:
- https://sentry.io/organizations/pocket/issues/2194211623/?environment=production&project=5503693&query=is%3Aunresolved&statsPeriod=14d

Slack thread:
- https://pocket.slack.com/archives/C03QVL4SU/p1636042691425700
- https://pocket.slack.com/archives/C02KH5U7G79/p1636065358002800