### PR TITLE
Put URL in the Candidate Set

### DIFF
--- a/aws_lambda/sqs_handler.py
+++ b/aws_lambda/sqs_handler.py
@@ -83,6 +83,7 @@ def _validate_candidate_set(candidate_set: Dict[str, Any]):
 
 def _validate_candidate(candidate: Dict[str, Any]):
     _validate_dict_value_type(candidate, 'item_id', int)
+    _validate_dict_value_type(candidate, 'url', str)
     _validate_dict_value_type(candidate, 'publisher', str)
 
 


### PR DESCRIPTION
Add validation for presence of url, the contemporary pocket primary key of record, in candidates before sticking them in DynamoDB.

As of this PR metaflow will add url to the SQS Queue: https://github.com/Pocket/dl-metaflow-jobs/pull/84

This PR is to the lambda that gets the candidate sets off the SQS Queue and puts them into DynamoDB. Now they will have their urls in there.

**Benefits**
- See aforementioned PR.

**Risks**
- We need to check if there is some kind of row size limit in Dynamo DB, and if so how close we are to it, and if we're close, whether adding a url to each of our candidates puts us over that limit. My hope on this is 'no' but if the answer is 'yes' things get more complicated.