### PR TITLE
Key on, collect item with, and surface url from the recs api

### DIFF
--- a/app/models/candidate.py
+++ b/app/models/candidate.py
@@ -4,4 +4,5 @@ from typing import Optional
 class Candidate(BaseModel):
     item_id: int
     publisher: str
+    url: str
     feed_id: Optional[int]

--- a/app/models/candidate_set.py
+++ b/app/models/candidate_set.py
@@ -93,7 +93,8 @@ class RecItCandidateSet(CandidateSetModel):
     def parse_recit_response(cs_id: str, response: Dict) -> "RecItCandidateSet":
         """Transforms a RecIt response to a CandidateSet. We set publisher to '0' since RecIt doesn't currently return
         publishers."""
-        candidates = [Candidate(item_id=r["resolved_id"], publisher="0") for r in response["items"]]
+        # TODO: Does Recit return the URL of record?
+        candidates = [Candidate(item_id=r["resolved_id"], publisher="0", url="placeholder.com") for r in response["items"]]
         return RecItCandidateSet(candidates=candidates, id=cs_id, version=1)
 
 

--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -36,6 +36,7 @@ class RecommendationModel(BaseModel):
     feed_item_id: str = None
     feed_id: int = None
     item_id: str
+    url: str
     item: ItemModel
     rec_src: str = 'RecommendationAPI'
     publisher: str = None
@@ -51,6 +52,7 @@ class RecommendationModel(BaseModel):
             feed_id=candidate.get('feed_id'),
             publisher=candidate.get('publisher'),
             item_id=candidate.get('item_id'),
+            url=candidate.get('url'),
             item=ItemModel(item_id=candidate.get('item_id'))
         )
         recommendation.id = recommendation.rec_src + '/' + recommendation.item.item_id

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
     """
-    Get the recomendations for a specific topic
+    Get the recommendations for a specific topic
     """
     getTopicRecommendations(slug: String!, algorithmicCount: Int = 20, curatedCount: Int = 5): TopicRecommendations  @deprecated(reason: "Use `getSlateLineup` with a specific SlateLineup instead.")
 
@@ -85,12 +85,12 @@ type Topic {
     curatorLabel: String!
 
     """
-    Whether or not clients should show this topic ot users
+    Whether or not clients should show this topic to users
     """
     isDisplayed: Boolean!
 
     """
-    Whether or not this topic should be visiblly promoted (prominent on the page)
+    Whether or not this topic should be visibly promoted (prominent on the page)
     """
     isPromoted: Boolean!
 
@@ -121,43 +121,47 @@ type Topic {
 }
 
 """
-Represents a set of recomednations for /explore
+Represents a set of recommendations for /explore
 Deprecated for SlateLineups
 """
 type TopicRecommendations {
     """
-    Recomendations that are sourced directly from our curators
+    Recommendations that are sourced directly from our curators
     """
     curatedRecommendations: [Recommendation!]!
 
     """
-    Recomendations that are sourced from Machine Learning models
+    Recommendations that are sourced from Machine Learning models
     """
     algorithmicRecommendations: [Recommendation!]!
 }
 
 """
-Represents a Recomendation from Pocket
+Represents a Recommendation from Pocket
 """
-type Recommendation @key(fields: "item { itemId }") {
+type Recommendation @key(fields: "item { url }") {
     """
-    A generated id from the Data and Learning team that represents the Recomendation
+    A generated id from the Data and Learning team that represents the Recommendation
     """
     id: ID
 
     """
-    A generated id from the Data and Learning team that represents the Recomendation - Deprecated
+    A generated id from the Data and Learning team that represents the Recommendation - Deprecated
     """
     feedItemId: ID @deprecated(reason: "Use `id`")
 
     """
-    The ID of the item this recomendation represents
-    TODO: Use apollo federation to turn this into an Item type.
+    The URL and ID of record for the item this recommendation represents
+    """
+    url: URL!
+
+    """
+    A deprecated ID that we still use for ranking
     """
     itemId: ID!
 
     """
-    The Item that is resolved by apollo federation using the itemId
+    The Item that is resolved by apollo federation using the givenUrl
     """
     item: Item!
 
@@ -178,7 +182,7 @@ type Recommendation @key(fields: "item { itemId }") {
 }
 
 """
-A grouping of item recomendations that relate to each other under a specific name and description
+A grouping of item recommendations that relate to each other under a specific name and description
 """
 type Slate {
     id: String!
@@ -196,7 +200,7 @@ type Slate {
     experimentId: ID!
 
     """
-    The name to show to the user for this set of recomendations
+    The name to show to the user for this set of recommendations
     """
     displayName: String
 
@@ -206,7 +210,7 @@ type Slate {
     description: String
 
     """
-    An ordered list of the recomendations to show to the user
+    An ordered list of the recommendations to show to the user
     """
     recommendations: [Recommendation!]!
 }
@@ -234,9 +238,7 @@ type SlateLineup {
     slates: [Slate!]!
 }
 
-extend type Item @key(fields: "itemId") {
-    """
-    The ID of the item that is used by apollo federation to reference the Item entity.
-    """
-    itemId: String! @external
+extend type Item @key(fields: "givenUrl") {
+  "key field to identify the Item entity in the Parser service"
+  givenUrl: Url! @external
 }


### PR DESCRIPTION
This would cover the API "frontend" changes for the changeover from itemID to url for which we changed the lambda here: https://github.com/Pocket/recommendation-api/pull/636

- I'd need to work with Mathijs on the appropriate way to test that this would work, particularly given that it possesses the federated component where it fetches information from the graph.
- This would be the final of the 3 PRs (the one referenced above and the one it references in Metaflow) to surface URL alongside itemID and use it where possible.

The other option besides these 3 PRs is to create a whole separate flow with a separate endpoint, as per @jeshuaborges' suggestion. I think that the work to implement _this_ attempt is useful context for trying _that_, which I can start on tomorrow, Tuesday, February 8. 