### PR TITLE
Fix Lambda tests

### DIFF
--- a/aws_lambda/tests/fixtures/lambda_sqs_event.py
+++ b/aws_lambda/tests/fixtures/lambda_sqs_event.py
@@ -7,13 +7,12 @@ from aws_lambda.sqs_handler import MINIMUM_EXPIRES_AT_FROM_NOW
 body = {
   "id": "1234-5678-ABCD-CEDF",
   "version": 1,
-  "expires_at": 1644006655,
+  "expires_at": int(time.time() + MINIMUM_EXPIRES_AT_FROM_NOW + 3600),  # Expires 1 hour after minimum
   "candidates": [
     {
       "item_id": 3242933715,
       "publisher": "TheAtlantic",
       "feed_id": 1,
-      "expires_at": int(time.time() + MINIMUM_EXPIRES_AT_FROM_NOW + 3600),  # Expires 1 hour after minimum
     }
   ]
 }


### PR DESCRIPTION
# Goal
Fix Lambda test failing:
```
AssertionError: expires_at 1644006655 should be at least 1644360869.5393023
```
The fixture had `expires_at` set on the wrong object, which caused tests to start failing after February 4, 2022. `expires_at` should be on the candidate set level, not on individual candidates.

## Reference

CircleCI error:
* https://app.circleci.com/pipelines/github/Pocket/recommendation-api/2313/workflows/663f2a0e-72af-4ed4-8429-e42399b824eb/jobs/9962

## Implementation Decisions
- Mocking `time.time()` might be a better way to test this logic, but I'm considering that out-of-scope for now.