### PR TITLE
Corpus thru ranker mathijs

### DIFF
--- a/app/data_providers/curation_api_client.py
+++ b/app/data_providers/curation_api_client.py
@@ -25,14 +25,11 @@ class CurationAPIClient(CurationAPIFetchable):
             "apollographql-client-version": "1"
         }
 
-        injection_protected_id = str(corpus_id)
-        injection_protected_start_date = str(start_date)
-
         query = f"""
         query RecsApiItemRequest {{
-            scheduledSurface(id: "{injection_protected_id}") {{
+            scheduledSurface(id: {json.dumps(str(corpus_id))}) {{
                 id
-                items(date: "{injection_protected_start_date}") {{
+                items(date: {json.dumps(str(start_date))}) {{
                   id
                 }}
             }}        

--- a/app/data_providers/metrics_client.py
+++ b/app/data_providers/metrics_client.py
@@ -17,6 +17,6 @@ class MetricsClient(MetricsFetchable):
         # If this turns into a skyscraper of conditionals I recommend we consider a jump table instead
         if ranker is firefox_thompson_sampling_1day:
             ranker_kwargs = {
-                'metrics': self.firefox_newtab_metrics_factory.get([rec.id for rec in ranked_items])
+                'metrics': await self.firefox_newtab_metrics_factory.get([rec.id for rec in ranked_items])
             }
         return ranker_kwargs

--- a/tests/unit/data_providers/test_metrics_client.py
+++ b/tests/unit/data_providers/test_metrics_client.py
@@ -20,7 +20,7 @@ class MockFirefoxNewtabMetricsFactory():
         )
     }
 
-    def get(self, recommendation_ids):
+    async def get(self, recommendation_ids):
         return self.mock_impressions
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Goal
- Fix 'coroutine was never awaited' exception
- Escape GraphQL parameters

# QA
1. `source <(maws -o awscli)` and choose `pocket-dev-PocketSSODataLearning`.
2. Select 'main Pocket-Dev' run configuration in Pycharm.
3. Run GraphQL query:
```graphql
query corpus_slate {
  getRankedCorpusSlate(slateId: "f99178fb-6bd0-4fa1-8109-cda181b697f6") {
    corpusItems {
      id
    }
  }
}
```