### PR TITLE
Add read access to personalizer-<env>-UserTopicProfileStore

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -9,7 +9,10 @@ const branch = isDev ? 'dev' : 'main';
 const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
+
+// ticket POC-98
 const userTopicProfileStore = 'UserTopicProfileStore'
+
 // aiocache currently does not support data partitioning, so there's little benefit to having more than 1 node.
 const cacheNodes = isDev ? 1 : 1;
 const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';

--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -11,6 +11,7 @@ const domain = isDev
   : `${domainPrefix}.readitlater.com`;
 
 // ticket POC-98
+// Note: Metaflow stack has an output PocketUserTopicProfileStoreRoleArn which could be imported.
 const userTopicProfileStore = 'UserTopicProfileStore'
 
 // aiocache currently does not support data partitioning, so there's little benefit to having more than 1 node.

--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -9,7 +9,7 @@ const branch = isDev ? 'dev' : 'main';
 const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
-
+const userTopicProfileStore = 'UserTopicProfileStore'
 // aiocache currently does not support data partitioning, so there's little benefit to having more than 1 node.
 const cacheNodes = isDev ? 1 : 1;
 const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';
@@ -29,6 +29,7 @@ export const config = {
   domain,
   recommendationMetricsDynamodbName: `MODELD-${environment}-RecMetrics`,
   slateMetricsDynamodbName: `MODELD-${environment}-SlateMetrics`,
+  metaFlowUserTopicProfileStore: `personalizer-${environment}-${userTopicProfileStore}`,
   cacheNodes,
   cacheSize,
   stateMachines: [

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -291,7 +291,8 @@ class RecommendationAPI extends TerraformStack {
                             `${dynamodb.metadataTable.dynamodb.arn}/*`,
                             `${dynamodb.recommendationMetricsTable.arn}/*`,
                             `${dynamodb.slateMetricsTable.arn}/*`,
-                            `${dynamodb.candidateSetsTable.dynamodb.arn}/*`
+                            `${dynamodb.candidateSetsTable.dynamodb.arn}/*`,
+                            `arn:aws:dynamodb:${region.name}:${caller.accountId}:table/${config.metaFlowUserTopicProfileStore}`
                         ],
                         effect: 'Allow'
                     },


### PR DESCRIPTION
# Goal

Allow read access to personalizer-<env>-UserTopicProfileStore dynamodb table from ECS task role. 

Tickets:
* POC-98