### PR TITLE
Fix `Topic.query` mismatch between code and schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -106,7 +106,7 @@ type Topic {
     """
     The query that was used internally for elasticsearch to find items
     """
-    query: [String!]!
+    query: String!
 
     """
     The label the curator uses internally to get items onto this topic


### PR DESCRIPTION
# Goal
Fix an issue that prevents `listTopics` from being run through ClientAPI, where it [returns null](https://studio.apollographql.com/graph/pocket-client-api/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABADICWAzigCoQAOZUFRwAOkkUQDaU32PM2HTkTJh2IohS4wA5hJGw8AQxQQ8JZQCMEXBZzCU6XZQQByyxPqI58Ba5QAiRkwQTjhnOstkJqBOgRrWCoIOAAxBHcASQ9OAF92eJB4oA&variant=current) if `query` is included. The root cause is that the GraphQL schema defined a different type than the [topic model](https://github.com/Pocket/recommendation-api/blob/main/app/models/topic.py#L28). The latter has the correct type.

## Reference

Slack thread:
* https://pocket.slack.com/archives/C02JZ4TRF0S/p1652210619681879

Related PR:
* https://github.com/Pocket/dl-metaflow-jobs/pull/80

## Implementation Decisions
This query is deprecated, but still in use in Metaflow. (See linked PR above.)