### PR TITLE
Deprecate getRankedCorpusSlate

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -44,7 +44,7 @@ type Query {
     """
     getRankedCorpusSlate(
         slateId: String!
-    ): RankedCorpusSlate
+    ): RankedCorpusSlate  @deprecated(reason: "This query is experimental and might not work as expected")
 }
 
 type RankedCorpusSlate @key(fields: "id") {


### PR DESCRIPTION
# Goal
`getRankedCorpusSlate` isn't used in production. Indicate that clients should not use `getRankedCorpusSlate` for the time being:
- It currently returns an [INTERNAL_SERVER_ERROR for the en-INTL New Tab](https://studio.apollographql.com/graph/pocket-client-api/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoDKANgIYoJHAA6SRRA5uQEo1IDWCMAGEIeAA4wAztToIAFJNr0AkmHREm4AJwAjAKx6wAFgBsAWgBmWgAxazRgMw0ATGYAcAdhNQzD6x7cjBBtbJ00ASkYWNjYoUQlJZXo4SSjWGLYUAEsUKgRojKIEAA8ofDEUAoyssCqiAF86sARJKDwsiqyIJALGpHqQeqA&variant=current)
- We will probably change this query when we return to this body of work, if only to conform to the new guideline of not including verbs in the query name.