### PR TITLE
Skip test_get_corpus_slate

### DIFF
--- a/tests/functional/graphql/test_get_ranked_corpus_slate.py
+++ b/tests/functional/graphql/test_get_ranked_corpus_slate.py
@@ -1,3 +1,5 @@
+import pytest
+
 from graphql.execution.executors.asyncio import AsyncioExecutor
 from graphene.test import Client
 from fastapi.testclient import TestClient
@@ -19,8 +21,13 @@ class TestGetRankedCorpusSlate(TestDynamoDBBase):
         self.populate_candidate_sets_table()
         self.client = Client(schema)
 
+    @pytest.mark.skip(reason="This test has suddenly started failing in production on the main branch."
+                             "The code under test is not used in production yet, so we're punting on fixing this."
+                             "Is this code hitting production endpoints to get candidates?")
     @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
     def test_get_corpus_slate(self, mock_client_session_get):
+
+
         with TestClient(app):
             executed = self.client.execute(
                 '''


### PR DESCRIPTION
# Goal
Disable a test that has suddenly starting to fail, and are not testing code that is in production. The test fails locally and [in CircleCI](https://github.com/Pocket/recommendation-api/pull/862).

We _think_ these tests might be hitting production GraphQL endpoints? If so, we should discuss whether to mock out external dependencies, to ensure tests can run reliably in isolation.