### PR TITLE
Rename setup moment endpoints

### DIFF
--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -34,7 +34,7 @@ class Query(ObjectType):
         CorpusSlate,
     )
 
-    user_content_profile_topics = Field(
+    recommendation_preference_topics = Field(
         List(Topic),
     )
 
@@ -98,7 +98,7 @@ class Query(ObjectType):
             ],
         )
 
-    async def resolve_user_content_profile_topics(self, info) -> [Topic]:
+    async def resolve_recommendation_preference_topics(self, info) -> [Topic]:
         topics = await TopicModel.get_all()
         exclude_topic_names = ['Gaming', 'Sports', 'Education', 'Coronavirus']
         return [t for t in topics if t.name not in exclude_topic_names]

--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -5,7 +5,7 @@ from app.data_providers.curation_api_client import CurationAPIClient
 from app.data_providers.metrics_client import MetricsClient
 from app.data_providers.slate_provider import SlateProvider
 from app.graphql.ranked_corpus_slate import RankedCorpusSlate
-from app.graphql.update_user_content_profile_mutation import UpdateUserContentProfile
+from app.graphql.update_user_recommendation_preferences_mutation import UpdateUserRecommendationPreferences
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.metrics.firefox_new_tab_metrics_factory import FirefoxNewTabMetricsFactory
 from app.models.ranked_corpus_slate_instance import RankedCorpusSlateInstance
@@ -105,7 +105,7 @@ class Query(ObjectType):
 
 
 class Mutation(ObjectType):
-    update_user_content_profile = UpdateUserContentProfile.Field()
+    update_user_recommendation_preferences = UpdateUserRecommendationPreferences.Field()
 
 
 ##

--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -88,11 +88,11 @@ class Query(ObjectType):
                     corpusItem=CorpusItemModel(id='b809c66c-4f8b-4e56-a9d4-67bb6f601a5b'),
                 ),
                 CorpusRecommendationModel(
-                    id='ca42bad7-6346-457b-b23b-ef583a3d3f5c',
+                    id='3177b6b1-8499-4395-9ad3-f4321cb2c8c8',
                     corpusItem=CorpusItemModel(id='69e9c46a-6859-4e77-a6c9-aa49ba5825bb'),
                 ),
                 CorpusRecommendationModel(
-                    id='ca42bad7-6346-457b-b23b-ef583a3d3f5c',
+                    id='7c09a422-d6d1-40b6-9e98-6171b259fc29',
                     corpusItem=CorpusItemModel(id='a43317f0-44c1-4ae8-ad14-e9e792a5ade7'),
                 ),
             ],

--- a/app/graphql/update_user_recommendation_preferences_input.py
+++ b/app/graphql/update_user_recommendation_preferences_input.py
@@ -3,7 +3,7 @@ import graphene
 from app.graphql.topic_input import TopicInput
 
 
-class UpdateUserContentProfileInput(graphene.InputObjectType):
+class UpdateUserRecommendationPreferencesInput(graphene.InputObjectType):
     preferredTopics = graphene.List(
         TopicInput,
         required=True,

--- a/app/graphql/update_user_recommendation_preferences_mutation.py
+++ b/app/graphql/update_user_recommendation_preferences_mutation.py
@@ -1,13 +1,13 @@
 import graphene
 
 from app.graphql.topic import Topic
-from app.graphql.update_user_content_profile_input import UpdateUserContentProfileInput
+from app.graphql.update_user_recommendation_preferences_input import UpdateUserRecommendationPreferencesInput
 from app.models.topic import TopicModel
 
 
-class UpdateUserContentProfile(graphene.Mutation):
+class UpdateUserRecommendationPreferences(graphene.Mutation):
     class Arguments:
-        input = UpdateUserContentProfileInput(required=True)
+        input = UpdateUserRecommendationPreferencesInput(required=True)
 
     preferred_topics = graphene.List(Topic, description="Topics that the user expressed interest in")
 
@@ -16,4 +16,4 @@ class UpdateUserContentProfile(graphene.Mutation):
         input_topic_ids = {t.id for t in input.preferredTopics}
         output_topics = [t for t in topics if t.id in input_topic_ids]
 
-        return UpdateUserContentProfile(preferred_topics=output_topics)
+        return UpdateUserRecommendationPreferences(preferred_topics=output_topics)

--- a/app/graphql/user_recommendation_preferences.py
+++ b/app/graphql/user_recommendation_preferences.py
@@ -3,5 +3,5 @@ import graphene
 from app.graphql.topic import Topic
 
 
-class UserContentProfile(graphene.ObjectType):
+class UserRecommendationPreferences(graphene.ObjectType):
     preferredTopics = graphene.List(Topic, description="Topics that the user expressed interest in")

--- a/schema.graphql
+++ b/schema.graphql
@@ -338,7 +338,7 @@ type Query {
     """
     List all topics that the user can express a preference for.
     """
-    userContentProfileTopics: [Topic!]!
+    recommendationPreferenceTopics: [Topic!]!
 
     """
     Get the recomendations for a specific topic

--- a/schema.graphql
+++ b/schema.graphql
@@ -95,17 +95,6 @@ type UserRecommendationPreferences {
     preferredTopics: [Topic!]
 }
 
-extend type User @key(fields: "id") {
-    #Note more properties exist here but are defined in another service.
-
-    """
-    User id, provided by the user service.
-    """
-    id: ID! @external
-
-    contentProfile: UserContentProfile
-}
-
 type RankedCorpusSlate @key(fields: "id") {
     id: ID!
     description: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -81,14 +81,14 @@ input TopicInput {
     id: ID!
 }
 
-input UpdateUserContentProfileInput {
+input UpdateUserRecommendationPreferencesInput {
     """
     Topics that the user expressed interest in.
     """
     preferredTopics: [TopicInput!]!
 }
 
-type UserContentProfile {
+type UserRecommendationPreferences {
     """
     Topics that the user expressed interest in.
     """
@@ -390,9 +390,9 @@ type Query {
 
 type Mutation {
     """
-    User content Profile are sent through a mutation in addition to a Snowplow event.
+    Updates user preferences for content recommendations across Pocket.
     """
-    updateUserContentProfile(
-        input: UpdateUserContentProfileInput!
-    ): UserContentProfile
+    updateUserRecommendationPreferences(
+        input: UpdateUserRecommendationPreferencesInput!
+    ): UserRecommendationPreferences
 }

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -1,0 +1,25 @@
+from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
+
+
+def populate_topics(table: DynamoDBServiceResource.Table):
+    table.put_item(Item={
+        'id': 'a187ffb4-5c6f-4079-bad9-92442e97bdd1',
+        "display_name": 'Technology',
+        "page_type": 'topic_page',
+        "slug": 'tech',
+        "query": 'query',
+        "curator_label": 'technology',
+        "is_displayed": True,
+        "is_promoted": False
+    })
+
+    table.put_item(Item={
+        'id': 'fea00efc-ee03-48f5-95dc-148550c0b69c',
+        "display_name": 'Gaming',
+        "page_type": 'topic_page',
+        "slug": 'tech',
+        "query": 'query',
+        "curator_label": 'gaming',
+        "is_displayed": True,
+        "is_promoted": False
+    })

--- a/tests/functional/graphql/test_recommendation_preference_topics.py
+++ b/tests/functional/graphql/test_recommendation_preference_topics.py
@@ -1,0 +1,45 @@
+import pytest
+
+from graphql.execution.executors.asyncio import AsyncioExecutor
+from graphene.test import Client
+from fastapi.testclient import TestClient
+
+from app.graphql.graphql_router import schema
+from app.main import app, load_slate_configs
+from tests.assets.topics import populate_topics
+from tests.functional.test_dynamodb_base import TestDynamoDBBase
+
+from unittest.mock import patch
+from collections import namedtuple
+
+MockResponse = namedtuple('MockResponse', 'status')
+
+
+class TestSetupMomentSlate(TestDynamoDBBase):
+    client: Client
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.client = Client(schema)
+
+    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
+    def test_setup_moment_slate(self, mock_client_session_get):
+        populate_topics(self.metadata_table)
+
+        with TestClient(app):
+            executed = self.client.execute(
+                '''
+                query RecommendationPreferenceTopics {
+                  recommendationPreferenceTopics {
+                    id
+                    name
+                  }
+                }
+                ''',
+                executor=AsyncioExecutor())
+
+            response = executed.get('data').get('recommendationPreferenceTopics')
+
+            # 'Gaming' is filtered out, so the only topic remaining is 'Technology'.
+            assert len(response) == 1
+            assert response[0]['name'] == 'Technology'

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -1,0 +1,49 @@
+import pytest
+
+from graphql.execution.executors.asyncio import AsyncioExecutor
+from graphene.test import Client
+from fastapi.testclient import TestClient
+
+from app.graphql.graphql_router import schema
+from app.main import app, load_slate_configs
+from tests.functional.test_dynamodb_base import TestDynamoDBBase
+
+from unittest.mock import patch
+from collections import namedtuple
+
+MockResponse = namedtuple('MockResponse', 'status')
+
+
+class TestSetupMomentSlate(TestDynamoDBBase):
+    client: Client
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.client = Client(schema)
+
+    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
+    def test_setup_moment_slate(self, mock_client_session_get):
+        with TestClient(app):
+            executed = self.client.execute(
+                '''
+                query SetupMomentSlate {
+                  setupMomentSlate {
+                    headline
+                    subheadline
+                    recommendations {
+                      id
+                      corpusItem {
+                        id
+                      }
+                    }
+                  }
+                }
+                ''',
+                context_value={'user_id': 'johnjacobjingleheimerschmidt'},
+                executor=AsyncioExecutor())
+
+            response = executed.get('data').get('setupMomentSlate')
+            assert response['headline'] == 'Save an article you find interesting'
+
+            recommendations = response['recommendations']
+            assert recommendations[0]['id'] != recommendations[1]['id']

--- a/tests/functional/graphql/test_update_user_recommendation_preferences.py
+++ b/tests/functional/graphql/test_update_user_recommendation_preferences.py
@@ -1,0 +1,55 @@
+import pytest
+
+from graphql.execution.executors.asyncio import AsyncioExecutor
+from graphene.test import Client
+from fastapi.testclient import TestClient
+
+from app.graphql.graphql_router import schema
+from app.main import app, load_slate_configs
+from tests.assets.topics import populate_topics
+from tests.functional.test_dynamodb_base import TestDynamoDBBase
+
+from unittest.mock import patch
+from collections import namedtuple
+
+MockResponse = namedtuple('MockResponse', 'status')
+
+
+class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
+    client: Client
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.client = Client(schema)
+
+    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
+    def test_update_user_recommendation_preferences(self, mock_client_session_get):
+        topics = populate_topics(self.metadata_table)
+
+        with TestClient(app):
+            executed = self.client.execute(
+                '''
+                mutation Mutation($input: UpdateUserRecommendationPreferencesInput!) {
+                  updateUserRecommendationPreferences(input: $input) {
+                    preferredTopics {
+                      id
+                      name
+                    }
+                  }
+                }
+                ''',
+                variables={
+                    "input": {
+                        "preferredTopics": [
+                            {"id": "a187ffb4-5c6f-4079-bad9-92442e97bdd1"},
+                        ]
+                    }
+                },
+                context_value={'user_id': 'johnjacobjingleheimerschmidt'},
+                executor=AsyncioExecutor())
+
+            response = executed.get('data').get('updateUserRecommendationPreferences')
+            preferred_topics = response['preferredTopics']
+
+            assert len(preferred_topics) == 1
+            assert preferred_topics[0]['name'] == 'Technology'


### PR DESCRIPTION
# Goal

1. Rename `UserContentProfile` to `UserRecommendationPreferences` to reflect the spec: https://github.com/Pocket/spec/pull/144/commits/54c92f057625fc6bdc950f2fffe7cf44bf3d5d59, based on suggestion from Matt C.
2. Remove `contentProfile` from `User` until we're ready to implement it. Clients won't need to fetch user preferences for v0 of the experiment, so this might be a while out.
3. Add functional tests
4. Make the mock ids in the `setupMomentSlate` unique to make the mock data more realistic.

## Reference

- Spec PR: https://github.com/Pocket/spec/pull/144
- [Slack](https://pocket.slack.com/archives/C01VDFM30J2/p1654542205108089?thread_ts=1653442540.283049&cid=C01VDFM30J2)

## Local QA
```graphql
query TestPreferenceTopics {
  recommendationPreferenceTopics {
    id
    name
  }
}

mutation TestUpdateTopics {
  updateUserRecommendationPreferences(input: {
    preferredTopics: [
      {id: "1134bf31-c167-4d00-8178-7e5b02b5fc01"},
      {id: "0ea5e739-7f95-4703-b824-5c5a4d834388"}
    ]
  }) {
    preferredTopics {
      id
    }
  }
}
```
