### PR TITLE
fix for android lineup

### DIFF
--- a/app/models/user_impressed_list.py
+++ b/app/models/user_impressed_list.py
@@ -25,9 +25,7 @@ class UserImpressedList:
 
         impressed_items = await self._query_item_list(user_id)
         if not impressed_items:
-            error_message = f"No returned impressed item list for user_id={user_id}"
-            logging.info(error_message)
-            raise PersonalizationError(error_message)
+            logging.info(f"No returned impressed item list for user_id={user_id}")
 
         return impressed_items
 


### PR DESCRIPTION
# Goal

Android request to recs-api is raising personalization error and failing to return any recommendations to android discover.

## Reference

[slack](https://pocket.slack.com/archives/C013MQ3NBN1/p1654545815622619)
## Implementation Decisions

remove raising of personalization error for users without impressed items