### PR TITLE
[HS-43] Setup moment fetch preferred topics

### DIFF
--- a/app/data_providers/topic_provider.py
+++ b/app/data_providers/topic_provider.py
@@ -1,0 +1,51 @@
+from enum import Enum
+
+import aioboto3
+from aws_xray_sdk.core import xray_recorder
+from boto3.dynamodb.conditions import Key
+from typing import List, Optional, Set, Sequence
+
+from app.config import dynamodb as dynamodb_config
+from app.models.topic import TopicModel
+
+
+class TopicProvider:
+
+    def __init__(self, aioboto3_session: aioboto3.session.Session):
+        self.aioboto3_session = aioboto3_session
+
+    @xray_recorder.capture_async('models_topic_get_all')
+    async def get_all(self) -> List[TopicModel]:
+        """
+        Retrieves all topics from dynamo db
+
+        :return: a list of TopicModel objects
+        """
+        async with self.aioboto3_session.resource('dynamodb', endpoint_url=dynamodb_config['endpoint_url']) as dynamodb:
+            table = await dynamodb.Table(dynamodb_config['metadata']['table'])
+            response = await table.scan()
+        return sorted(list(map(TopicModel.from_dict, response['Items'])), key=lambda topic: topic.slug)
+
+    async def get_topics(self, topics_ids: Sequence[str]) -> List[TopicModel]:
+        """
+        :param topics_ids: List or tuple of topic ids. Invalid ids are ignored.
+        :return: A list of TopicModel objects for the given topic_ids.
+        """
+        all_topics = await self.get_all()
+        topics_by_id = {topic.id: topic for topic in all_topics}
+        return [topics_by_id[topic_id] for topic_id in topics_ids if topic_id in topics_by_id]
+
+    @xray_recorder.capture_async('models_topic_get_topic')
+    async def get_topic(self, slug: str) -> TopicModel:
+        """
+        Retrieves a single topic from dynamo db
+
+        :param slug: string slug of the topic to be retrieved
+        :return: a TopicModel object
+        """
+        async with aioboto3.resource('dynamodb', endpoint_url=dynamodb_config['endpoint_url']) as dynamodb:
+            table = await dynamodb.Table(dynamodb_config['metadata']['table'])
+            response = await table.query(IndexName='slug', Limit=1, KeyConditionExpression=Key('slug').eq(slug))
+        if response['Items']:
+            return TopicModel.from_dict(response['Items'][0])
+        raise ValueError('Topic not found')

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -107,4 +107,4 @@ class UserRecommendationPreferencesProvider:
 
     @classmethod
     def _topic_feature_from_topic(cls, topic: TopicModel) -> Dict[str, str]:
-        return {'id': topic.id, 'corpus_topic_id': topic.corpus_topic_id}
+        return {'id': topic.id}

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -57,4 +57,4 @@ class UserRecommendationPreferencesProvider:
 
     @classmethod
     def _topic_feature_from_topic(cls, topic: TopicModel) -> Dict[str, str]:
-        return {'id': topic.id}
+        return {'id': topic.id, 'corpus_topic_id': topic.corpus_topic_id}

--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -5,6 +5,7 @@ from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureG
 from app.data_providers.corpus.curated_corpus_api_client import CuratedCorpusAPIClient
 from app.data_providers.metrics_client import MetricsClient, MetricsFetchable
 from app.data_providers.slate_provider import SlateProvider
+from app.data_providers.topic_provider import TopicProvider
 from app.graphql.ranked_corpus_slate import RankedCorpusSlate
 from app.graphql.update_user_recommendation_preferences_mutation import UpdateUserRecommendationPreferences
 from app.models.corpus_item_model import CorpusItemModel
@@ -50,7 +51,7 @@ class Query(ObjectType):
                                                       description="Maximum number of recommendations to return, defaults to 10"))
 
     async def resolve_list_topics(self, info) -> [TopicModel]:
-        return await TopicModel.get_all()
+        return await TopicProvider(aioboto3_session=aioboto3.Session()).get_all()
 
     async def resolve_get_slate(self, info, slate_id: str, recommendation_count: int = None) -> SlateModel:
         return await SlateModel.get_slate(slate_id=slate_id, user_id=info.context.get('user_id'),
@@ -80,7 +81,7 @@ class Query(ObjectType):
         return await SetupMomentDispatch(corpus_client=corpus_client).get_ranked_corpus_slate()
 
     async def resolve_recommendation_preference_topics(self, info) -> [Topic]:
-        topics = await TopicModel.get_all()
+        topics = await TopicProvider(aioboto3_session=aioboto3.Session()).get_all()
         exclude_topic_names = ['Gaming', 'Sports', 'Education', 'Coronavirus']
         return [t for t in topics if t.name not in exclude_topic_names]
 

--- a/app/graphql/update_user_recommendation_preferences_mutation.py
+++ b/app/graphql/update_user_recommendation_preferences_mutation.py
@@ -3,10 +3,10 @@ import datetime
 import aioboto3
 import graphene
 
+from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
 from app.graphql.topic import Topic
 from app.graphql.update_user_recommendation_preferences_input import UpdateUserRecommendationPreferencesInput
-from app.models.topic import TopicModel
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 
 
@@ -17,12 +17,21 @@ class UpdateUserRecommendationPreferences(graphene.Mutation):
     preferred_topics = graphene.List(Topic, description="Topics that the user expressed interest in")
 
     async def mutate(root, info, input):
+        aioboto3_session = aioboto3.Session()
+
+        topic_provider = TopicProvider(aioboto3_session=aioboto3_session)
+
+        preferences_provider = UserRecommendationPreferencesProvider(
+            aioboto3_session=aioboto3_session,
+            topic_provider=topic_provider
+        )
+
         model = UserRecommendationPreferencesModel(
             user_id=info.context.get('user_id'),
             updated_at=datetime.datetime.utcnow(),
-            preferred_topics=await TopicModel.get_topics({t.id for t in input.preferredTopics})
+            preferred_topics=await topic_provider.get_topics([t.id for t in input.preferredTopics])
         )
 
-        await UserRecommendationPreferencesProvider(aioboto3_session=aioboto3.Session()).put(model)
+        await preferences_provider.put(model)
 
         return UpdateUserRecommendationPreferences(preferred_topics=model.preferred_topics)

--- a/app/models/topic.py
+++ b/app/models/topic.py
@@ -1,12 +1,6 @@
-import aioboto3
-
-from aws_xray_sdk.core import xray_recorder
-from boto3.dynamodb.conditions import Key
 from enum import Enum
 from pydantic import BaseModel
-from typing import Dict, Optional, Set
-
-from app.config import dynamodb as dynamodb_config
+from typing import Dict
 
 
 class PageType(str, Enum):
@@ -41,42 +35,3 @@ class TopicModel(BaseModel):
     def from_dict(item: Dict) -> 'TopicModel':
         # Map display_name to name. display_name is being deprecated, but still present in the database.
         return TopicModel.parse_obj(dict({'name': item['display_name']}, **item))
-
-    @staticmethod
-    @xray_recorder.capture_async('models_topic_get_all')
-    async def get_all() -> ['TopicModel']:
-        """
-        Retrieves all topics from dynamo db
-
-        :return: a list of TopicModel objects
-        """
-        async with aioboto3.resource('dynamodb', endpoint_url=dynamodb_config['endpoint_url']) as dynamodb:
-            table = await dynamodb.Table(dynamodb_config['metadata']['table'])
-            response = await table.scan()
-        return sorted(list(map(TopicModel.from_dict, response['Items'])), key=lambda topic: topic.slug)
-
-    @staticmethod
-    async def get_topics(topics_ids: Set[str]) -> ['TopicModel']:
-        """
-        Retrieves all topics from dynamo db
-
-        :return: a list of TopicModel objects
-        """
-        all_topics = await TopicModel.get_all()
-        return [t for t in all_topics if t.id in topics_ids]
-
-    @staticmethod
-    @xray_recorder.capture_async('models_topic_get_topic')
-    async def get_topic(slug: str) -> Optional['TopicModel']:
-        """
-        Retrieves a single topic from dynamo db
-
-        :param slug: string slug of the topic to be retrieved
-        :return: a TopicModel object
-        """
-        async with aioboto3.resource('dynamodb', endpoint_url=dynamodb_config['endpoint_url']) as dynamodb:
-            table = await dynamodb.Table(dynamodb_config['metadata']['table'])
-            response = await table.query(IndexName='slug', Limit=1, KeyConditionExpression=Key('slug').eq(slug))
-        if response['Items']:
-            return TopicModel.from_dict(response['Items'][0])
-        raise ValueError('Topic not found')

--- a/app/models/topic.py
+++ b/app/models/topic.py
@@ -16,7 +16,6 @@ class TopicModel(BaseModel):
     Models a topic, e.g. Technology, Gaming.
     """
     id: str
-    corpus_topic_id: str
     name: str
     display_name: str
     page_type: PageType

--- a/app/models/topic.py
+++ b/app/models/topic.py
@@ -22,6 +22,7 @@ class TopicModel(BaseModel):
     Models a topic, e.g. Technology, Gaming.
     """
     id: str
+    corpus_topic_id: str
     name: str
     display_name: str
     page_type: PageType

--- a/tests/assets/json/user_recommendation_preferences.json
+++ b/tests/assets/json/user_recommendation_preferences.json
@@ -10,7 +10,7 @@
     },
     {
       "FeatureName": "preferred_topics",
-      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\", \"corpus_topic_id\": \"BUSINESS\"}, {\"id\": \"45f8e740-42e0-4f54-8363-21310a084f1f\", \"corpus_topic_id\": \"SELF_IMPROVEMENT\"}]"
+      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\", \"corpus_topic_id\": \"BUSINESS\"}, {\"id\": \"25c716f1-e1b2-43db-bf52-1a5553d9fb74\", \"corpus_topic_id\": \"TECHNOLOGY\"}]"
     }
   ]
 ]

--- a/tests/assets/json/user_recommendation_preferences.json
+++ b/tests/assets/json/user_recommendation_preferences.json
@@ -10,7 +10,7 @@
     },
     {
       "FeatureName": "preferred_topics",
-      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\", \"corpus_topic_id\": \"BUSINESS\"}, {\"id\": \"25c716f1-e1b2-43db-bf52-1a5553d9fb74\", \"corpus_topic_id\": \"TECHNOLOGY\"}]"
+      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\"}, {\"id\": \"25c716f1-e1b2-43db-bf52-1a5553d9fb74\"}]"
     }
   ]
 ]

--- a/tests/assets/json/user_recommendation_preferences.json
+++ b/tests/assets/json/user_recommendation_preferences.json
@@ -1,0 +1,16 @@
+[
+  [
+    {
+      "FeatureName": "user_id",
+      "ValueAsString": "12341234"
+    },
+    {
+      "FeatureName": "updated_at",
+      "ValueAsString": "2022-06-07T23:00:48Z"
+    },
+    {
+      "FeatureName": "preferred_topics",
+      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\", \"corpus_topic_id\": \"BUSINESS\"}, {\"id\": \"45f8e740-42e0-4f54-8363-21310a084f1f\", \"corpus_topic_id\": \"SELF_IMPROVEMENT\"}]"
+    }
+  ]
+]

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -4,8 +4,9 @@ from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 
 from app.models.topic import PageType, TopicModel
 
+
 business_topic = TopicModel(
-    id='a187ffb4-5c6f-4079-bad9-asd23234234',
+    id='1bf756c0-632f-49e8-9cce-324f38f4cc71',
     corpus_topic_id='BUSINESS',
     name='Business',
     display_name='Business',
@@ -19,7 +20,7 @@ business_topic = TopicModel(
 )
 
 technology_topic = TopicModel(
-    id='a187ffb4-5c6f-4079-bad9-92442e97bdd1',
+    id='25c716f1-e1b2-43db-bf52-1a5553d9fb74',
     corpus_topic_id='TECHNOLOGY',
     name='Technology',
     display_name='Technology',
@@ -44,10 +45,16 @@ gaming_topic = TopicModel(
     page_type=PageType.topic_page
 )
 
+all_topic_fixtures = [
+    business_topic,
+    gaming_topic,
+    technology_topic,
+]
+
 
 def populate_topics(table: DynamoDBServiceResource.Table, topics: List[TopicModel] = None):
     if topics is None:
-        topics = [business_topic, technology_topic]
+        topics = all_topic_fixtures
 
     for topic in topics:
         table.put_item(Item=topic.dict())

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -6,6 +6,7 @@ from app.models.topic import PageType, TopicModel
 
 business_topic = TopicModel(
     id='a187ffb4-5c6f-4079-bad9-asd23234234',
+    corpus_topic_id='BUSINESS',
     name='Business',
     display_name='Business',
     slug='business',
@@ -19,6 +20,7 @@ business_topic = TopicModel(
 
 technology_topic = TopicModel(
     id='a187ffb4-5c6f-4079-bad9-92442e97bdd1',
+    corpus_topic_id='TECHNOLOGY',
     name='Technology',
     display_name='Technology',
     slug='tech',
@@ -31,6 +33,7 @@ technology_topic = TopicModel(
 
 gaming_topic = TopicModel(
     id='fea00efc-ee03-48f5-95dc-148550c0b69c',
+    corpus_topic_id='GAMING',
     name='Gaming',
     display_name='Gaming',
     slug='gaming',

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -7,7 +7,6 @@ from app.models.topic import PageType, TopicModel
 
 business_topic = TopicModel(
     id='1bf756c0-632f-49e8-9cce-324f38f4cc71',
-    corpus_topic_id='BUSINESS',
     name='Business',
     display_name='Business',
     slug='business',
@@ -21,7 +20,6 @@ business_topic = TopicModel(
 
 technology_topic = TopicModel(
     id='25c716f1-e1b2-43db-bf52-1a5553d9fb74',
-    corpus_topic_id='TECHNOLOGY',
     name='Technology',
     display_name='Technology',
     slug='tech',
@@ -57,4 +55,7 @@ def populate_topics(table: DynamoDBServiceResource.Table, topics: List[TopicMode
         topics = all_topic_fixtures
 
     for topic in topics:
-        table.put_item(Item=topic.dict())
+        topic_dict = topic.dict()
+        # Simulate corpus_topic_id being stored in DynamoDB, without it being present on the model yet.
+        topic_dict['corpus_topic_id'] = topic.name.upper()
+        table.put_item(Item=topic_dict)

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -32,7 +32,6 @@ technology_topic = TopicModel(
 
 gaming_topic = TopicModel(
     id='fea00efc-ee03-48f5-95dc-148550c0b69c',
-    corpus_topic_id='GAMING',
     name='Gaming',
     display_name='Gaming',
     slug='gaming',

--- a/tests/functional/graphql/test_recommendation_preference_topics.py
+++ b/tests/functional/graphql/test_recommendation_preference_topics.py
@@ -22,8 +22,7 @@ class TestRecommendationPreferenceTopics(TestDynamoDBBase):
         await super().asyncSetUp()
         self.client = Client(schema)
 
-    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
-    def test_recommendation_preference_topics(self, mock_client_session_get):
+    def test_recommendation_preference_topics(self):
         populate_topics(self.metadata_table, topics=[technology_topic, gaming_topic])
 
         with TestClient(app):

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -24,9 +24,8 @@ class TestSetupMomentSlate(TestDynamoDBBase):
         await super().asyncSetUp()
         self.client = Client(schema)
 
-    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
     @patch.object(CorpusFeatureGroupClient, 'get_corpus_items')
-    def test_setup_moment_slate(self, mock_get_ranked_corpus_items, mock_client_session_get):
+    def test_setup_moment_slate(self, mock_get_ranked_corpus_items):
         corpus_items_fixture = self._get_corpus_items_fixture()
         mock_get_ranked_corpus_items.return_value = corpus_items_fixture
 

--- a/tests/functional/graphql/test_topic_metadata_graphql.py
+++ b/tests/functional/graphql/test_topic_metadata_graphql.py
@@ -1,6 +1,7 @@
 from graphql.execution.executors.asyncio import AsyncioExecutor
 from graphene.test import Client
 from app.graphql.graphql_router import schema
+from tests.assets.topics import populate_topics, technology_topic
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
 
@@ -9,27 +10,15 @@ class TestGraphQLMetadata(TestDynamoDBBase):
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.populate_metadata_table()
+        populate_topics(self.metadata_table, topics=[technology_topic])
         self.client = Client(schema)
 
     def test_main_list_topics(self):
-        executed = self.client.execute('''{ listTopics { displayName} }''', executor=AsyncioExecutor())
+        executed = self.client.execute('''{ listTopics { name } }''', executor=AsyncioExecutor())
         assert executed == {
             'data': {
                 'listTopics': [{
-                    'displayName': 'tech'
+                    'name': 'Technology'
                 }]
             }
         }
-
-    def populate_metadata_table(self):
-        self.metadata_table.put_item(Item={
-            'id': 'a187ffb4-5c6f-4079-bad9-92442e97bdd1',
-            "display_name": 'tech',
-            "page_type": 'topic_page',
-            "slug": 'tech',
-            "query": 'query',
-            "curator_label": 'technology',
-            "is_displayed": True,
-            "is_promoted": False
-        })

--- a/tests/functional/graphql/test_update_user_recommendation_preferences.py
+++ b/tests/functional/graphql/test_update_user_recommendation_preferences.py
@@ -22,9 +22,8 @@ class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
         populate_topics(self.metadata_table)
         self.client = Client(schema)
 
-    @patch('aiohttp.ClientSession.get', to_return=MockResponse(status=200))
     @patch.object(UserRecommendationPreferencesProvider, 'put')
-    def test_update_user_recommendation_preferences(self, mock_data_provider_put, mock_client_session_get):
+    def test_update_user_recommendation_preferences(self, mock_data_provider_put):
         topics = populate_topics(self.metadata_table)
         user_id = 'johnjacobjingleheimerschmidt'
 

--- a/tests/functional/models/test_topic_metadata_model.py
+++ b/tests/functional/models/test_topic_metadata_model.py
@@ -1,22 +1,25 @@
+import aioboto3
+
+from app.data_providers.topic_provider import TopicProvider
 from tests.assets.topics import business_topic, technology_topic, populate_topics
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
-from app.models.topic import TopicModel
 
 
 class TestTopicMetadata(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        populate_topics(self.metadata_table)
+        populate_topics(self.metadata_table, topics=[business_topic, technology_topic])
+        self.topic_provider = TopicProvider(aioboto3_session=aioboto3.Session())
 
     async def test_main_list_topics(self):
-        executed = await TopicModel.get_all()
+        executed = await self.topic_provider.get_all()
         assert executed == [business_topic, technology_topic]
 
     async def test_main_get_topic(self):
-        executed = await TopicModel.get_topic('business')
+        executed = await self.topic_provider.get_topic('business')
         assert executed == business_topic
 
     async def test_main_get_nonexistent_topic(self):
         with self.assertRaises(ValueError):
-            await TopicModel.get_topic(slug='stonks')
+            await self.topic_provider.get_topic(slug='stonks')
 

--- a/tests/mocks/topic_provider.py
+++ b/tests/mocks/topic_provider.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from app.data_providers.topic_provider import TopicProvider
+from app.models.topic import TopicModel
+from tests.assets.topics import all_topic_fixtures
+
+
+class MockTopicProvider(TopicProvider):
+
+    async def get_all(self) -> List[TopicModel]:
+        return all_topic_fixtures
+
+    async def get_topic(self, slug: str) -> TopicModel:
+        for topic in all_topic_fixtures:
+            if topic.slug == slug:
+                return topic

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
@@ -1,11 +1,13 @@
 import datetime
 import json
 import os
+
+import aioboto3
 import pytest
 
 from aws_xray_sdk import global_sdk_config
 
-import app.config
+from app.config import ROOT_DIR
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 from tests.assets.topics import technology_topic
@@ -21,13 +23,13 @@ class TestUserRecommendationPreferencesProvider:
         self.feature_store_mock = FeatureStoreMock(
             feature_group_name=UserRecommendationPreferencesProvider.get_feature_group_name(),
             identifier_feature_name='user_id',
-            records_json_path=os.path.join(app.config.ROOT_DIR, 'tests/assets/json/corpus_candidate_sets.json')
+            records_json_path=os.path.join(ROOT_DIR, 'tests/assets/json/user_recommendation_preferences.json')
         )
 
         # This is the client that's under test.
         self.client = UserRecommendationPreferencesProvider(self.feature_store_mock.aioboto3)
 
-    async def test_new_user(self):
+    async def test_put(self):
         """
         Test the case where the queried records exist in the Feature Group.
         """
@@ -50,3 +52,11 @@ class TestUserRecommendationPreferencesProvider:
         assert len(preferred_topics_feature) == 1
         assert preferred_topics_feature[0]['id'] == model.preferred_topics[0].id
         assert preferred_topics_feature[0]['corpus_topic_id'] == model.preferred_topics[0].corpus_topic_id
+
+    async def test_fetch(self):
+        """
+        Test the case where the queried records exist in the Feature Group.
+        """
+        model = await self.client.fetch('12341234')
+
+        print(model)

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
@@ -49,3 +49,4 @@ class TestUserRecommendationPreferencesProvider:
         preferred_topics_feature = json.loads(features['preferred_topics'])
         assert len(preferred_topics_feature) == 1
         assert preferred_topics_feature[0]['id'] == model.preferred_topics[0].id
+        assert preferred_topics_feature[0]['corpus_topic_id'] == model.preferred_topics[0].corpus_topic_id

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
@@ -55,7 +55,6 @@ class TestUserRecommendationPreferencesProvider:
         preferred_topics_feature = json.loads(features['preferred_topics'])
         assert len(preferred_topics_feature) == 1
         assert preferred_topics_feature[0]['id'] == model.preferred_topics[0].id
-        assert preferred_topics_feature[0]['corpus_topic_id'] == model.preferred_topics[0].corpus_topic_id
 
     async def test_fetch(self):
         """


### PR DESCRIPTION
# Goal
Allow user recommendation preferences to be fetched by implementing `UserRecommendationPreferencesProvider.fetch`.

Additional changes:
- Move methods from `TopicModel` to `TopicProvider` that fetch topics from DynamoDB. This is part of moving to the [data mapper pattern](https://en.wikipedia.org/wiki/Data_mapper_pattern).
- Simulate `corpus_topic_id` being stored in DynamoDB, to make sure that we can add a column to the topic DynamoDB table without breaking anything. In the next PR, I'll add this field to the model and use it for ranking.
- Clean up tests a bit:
   - Use accurate topic ids in `tests/assets/topics.py`
   - Remove patches for `aiohttp.ClientSession.get` where its unused
   - Replace fixture code in tests with imported fixtures

# References
Jira issue:
- https://getpocket.atlassian.net/browse/HS-43

# Deployment
No deployment steps necessary for this PR. For the subsequent ranking PR, I'll pair to add `corpus_topic_id` to the DynamoDB topic table.
