### PR TITLE
[HS-62] Allow clients to limit recommendation count in setupMomentSlate

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -29,12 +29,13 @@ class SetupMomentDispatch:
         self.corpus_client = corpus_client
         self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
 
-    async def get_ranked_corpus_slate(self, user_id: str) -> CorpusSlateModel:
+    async def get_ranked_corpus_slate(self, user_id: str, recommendation_count: int) -> CorpusSlateModel:
         items = await self.corpus_client.get_corpus_items(self.CORPUS_IDS)
 
         user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(user_id)
         items = rank_by_preferred_topics(items, preferred_topics=user_recommendation_preferences.preferred_topics)
 
+        items = items[:recommendation_count]
         recommendations = [CorpusRecommendationModel(id=uuid.uuid4().hex, corpus_item=item) for item in items]
 
         return CorpusSlateModel(

--- a/app/graphql/corpus_slate.py
+++ b/app/graphql/corpus_slate.py
@@ -1,8 +1,14 @@
 from graphene_pydantic import PydanticObjectType
+from graphene import List, Int
 
+from app.graphql.corpus_recommendation import CorpusRecommendation
 from app.models.corpus_slate_model import CorpusSlateModel
 
 
 class CorpusSlate(PydanticObjectType):
+    DEFAULT_COUNT = 10
+
+    recommendations = List(CorpusRecommendation, required=True, count=Int(default_value=DEFAULT_COUNT))
+
     class Meta:
         model = CorpusSlateModel

--- a/app/graphql/util.py
+++ b/app/graphql/util.py
@@ -1,0 +1,43 @@
+from typing import List
+
+import graphql.language.ast
+
+
+def get_field_argument(
+        fields: List[graphql.language.ast.Field],
+        field_path: List[str],
+        argument_name: str,
+        default_value=None
+):
+    """
+    Returns the value of a GraphQL field argument. In the following example the return value is  '3':
+    query { setupMomentSlate{ recommendations(count: 3) { id } } }
+
+    This function feels like it should be implemented in a GraphQL library. Graphene provides easy access to top-level
+    query arguments, but I could not find an easy way to access arguments on other fields.
+    Graphene has been deprecated from FastAPI/Starlette, and the recommended GraphQL library is now Strawberry.
+    Perhaps Strawberry handles field arguments better?
+
+    :param fields: List of GraphQL fields, which can be obtained from `graphql.ResolveInfo.field_asts`.
+    :param field_path: GraphQL field names to traverse. ['setupMomentSlate', 'recommendations'] in the above example.
+    :param argument_name: Name of the argument. 'count' in the above example.
+    :param default_value: The value to return if the field and/or argument is missing from the query.
+    :return: Field argument value in string representation, or `default_value` if field argument is not present.
+    """
+    for field in fields:
+        if field.name.value == field_path[0]:
+            if len(field_path) == 1:
+                # End of recursion: We've reached the desired field, and can now find the argument.
+                for argument in field.arguments:
+                    if argument.name.value == argument_name:
+                        return argument.value.value
+            else:
+                # Recursion with the next level of fields, with the first element from `field_path` removed.
+                return get_field_argument(
+                    fields=field.selection_set.selections,
+                    field_path=field_path[1:],
+                    argument_name=argument_name,
+                    default_value=default_value
+                )
+
+    return default_value

--- a/tests/unit/graphql/test_get_field_argument.py
+++ b/tests/unit/graphql/test_get_field_argument.py
@@ -1,0 +1,83 @@
+import unittest
+
+from graphql.language.ast import Field, Name, SelectionSet, Argument, IntValue
+
+from app.graphql.util import get_field_argument
+
+
+def _setup_moment_slate_field_fixture(query_name: str = 'setupMomentSlate', count_value: int = 3):
+    return Field(
+        name=Name(value=query_name),
+        selection_set=SelectionSet(selections=[
+            Field(name=Name(value='id')),
+            Field(name=Name(value='headline')),
+            Field(
+                name=Name(value='recommendations'),
+                arguments=[Argument(name=Name(value='count'), value=IntValue(value=f'{count_value}'))],
+                selection_set=SelectionSet(selections=[
+                    Field(name=Name(value='id')),
+                    Field(
+                        name=Name(value='corpusItem'),
+                        selection_set=SelectionSet(selections=[Field(name=Name(value='id'))])
+                    ),
+                ])
+            )
+        ])
+    )
+
+
+_setup_moment_slate_fields_fixture = [_setup_moment_slate_field_fixture()]
+
+
+class TestGetFieldArgument(unittest.TestCase):
+
+    def test_existing_field_argument(self):
+        argument_value = get_field_argument(
+            _setup_moment_slate_fields_fixture,
+            field_path=['setupMomentSlate', 'recommendations'],
+            argument_name='count',
+        )
+
+        assert argument_value == '3'
+
+    def test_multiple_queries(self):
+        multiple_queries_fixture = [
+            _setup_moment_slate_field_fixture(query_name='aDifferentQuery', count_value=123),
+            _setup_moment_slate_field_fixture(),
+        ]
+
+        argument_value = get_field_argument(
+            multiple_queries_fixture,
+            field_path=['setupMomentSlate', 'recommendations'],
+            argument_name='count'
+        )
+
+        assert argument_value == '3'
+
+    def test_non_existing_field(self):
+        argument_value = get_field_argument(
+            _setup_moment_slate_fields_fixture,
+            field_path=['setupMomentSlate', 'fooBar'],
+            argument_name='count',
+        )
+
+        assert argument_value is None
+
+    def test_non_existing_argument(self):
+        argument_value = get_field_argument(
+            _setup_moment_slate_fields_fixture,
+            field_path=['setupMomentSlate', 'recommendations'],
+            argument_name='fooBar',
+        )
+
+        assert argument_value is None
+
+    def test_non_existing_argument_returns_default_value(self):
+        argument_value = get_field_argument(
+            _setup_moment_slate_fields_fixture,
+            field_path=['setupMomentSlate', 'recommendations'],
+            argument_name='fooBar',
+            default_value=123
+        )
+
+        assert argument_value == 123


### PR DESCRIPTION
# Goal
Allow clients to limit the number of recommendation that `setupMomentSlate` returns.

## Todos
- [ ] Test locally
- [ ] Test in Apollo using a Pocket-Dev deployment

## Reference

Tickets:
* [Link to JIRA tickets](https://getpocket.atlassian.net/browse/HS-62)

## Implementation Decisions
- As far as I can tell, Graphene does not make it easy to access field arguments, so I wrote a utility function for this.