### PR TITLE
[HS-63][HS-65] Fix Setup Moment bugs

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -297,6 +297,7 @@ class RecommendationAPI extends TerraformStack {
                     },
                     {
                         actions: [
+                            'sagemaker:PutRecord',
                             'sagemaker:BatchGetRecord',
                             'sagemaker:GetRecord',
                             'sagemaker:DescribeFeatureGroup',

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -33,7 +33,8 @@ class SetupMomentDispatch:
         items = await self.corpus_client.get_corpus_items(self.CORPUS_IDS)
 
         user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(user_id)
-        items = rank_by_preferred_topics(items, preferred_topics=user_recommendation_preferences.preferred_topics)
+        if user_recommendation_preferences:
+            items = rank_by_preferred_topics(items, preferred_topics=user_recommendation_preferences.preferred_topics)
 
         items = items[:recommendation_count]
         recommendations = [CorpusRecommendationModel(id=uuid.uuid4().hex, corpus_item=item) for item in items]

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
@@ -35,6 +36,8 @@ class SetupMomentDispatch:
         user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(user_id)
         if user_recommendation_preferences:
             items = rank_by_preferred_topics(items, preferred_topics=user_recommendation_preferences.preferred_topics)
+        else:
+            logging.info(f'SetupMoment is unpersonalized for user {user_id} because no preferences were found.')
 
         items = items[:recommendation_count]
         recommendations = [CorpusRecommendationModel(id=uuid.uuid4().hex, corpus_item=item) for item in items]

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -26,7 +26,7 @@ class UserRecommendationPreferencesProvider:
         """
         await self._put_feature_store_record(model)
 
-    async def fetch(self, user_id: str) -> UserRecommendationPreferencesModel:
+    async def fetch(self, user_id: str) -> Optional[UserRecommendationPreferencesModel]:
         """
         Gets user recommendation preferences for a given user id.
         :param user_id:
@@ -36,6 +36,9 @@ class UserRecommendationPreferencesProvider:
             raise ValueError('user_id is required in UserRecommendationPreferencesProvider.fetch')
 
         feature_store_record = await self._get_feature_store_record(user_id)
+        if not feature_store_record:
+            return None
+
         model = await self._model_from_feature_store_record(feature_store_record)
         return model
 

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
@@ -64,3 +64,12 @@ class TestUserRecommendationPreferencesProvider:
         # Assert model matches fixture data in user_recommendation_preferences.json
         assert model.user_id == '12341234'
         assert model.preferred_topics == [business_topic, technology_topic]
+
+    async def test_fetch_non_existing_user(self):
+        """
+        Test the case where the queried records exist in the Feature Group.
+        """
+        model = await self.client.fetch('9999')
+
+        # Assert model matches fixture data in user_recommendation_preferences.json
+        assert model is None


### PR DESCRIPTION
# Goal
- [HS-63](https://getpocket.atlassian.net/browse/HS-63) When calling `setupMomentSlate`: an error occurred "'NoneType' object is not subscriptable". This happened when the user did not have a record in the feature group with user recommendation preferences.
- [HS-65](https://getpocket.atlassian.net/browse/HS-65) When calling `updateUserRecommendationPreferences`: "an error occurred (AccessDeniedException) when calling the PutRecord operation." This happens because RecommendationAPI did not have access to `sagemaker:PutRecord` on the feature group with user recommendation preferences.

## Implementation Decisions
- We've started a strategy of creating shared policies for services, but RecommendationAPI doesn't contain this policy yet. Unless someone feels strongly, I'd prefer to keep applying the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) in client-facing services like RecommendationAPI.
- I'm returning `None` when there are no recommendation preferences for a user_id. Alternatively I could've raised an exception. Happy to move to an exception if anyone prefers that.

## QA
Run the following queries on the Dev VPN.

### updateUserRecommendationPreferences
```shell
curl --location --request POST 'https://recommendation-api.getpocket.dev' \
--header 'userId: 123456789' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": "mutation PostmanUpdateUserRecommendationPreferences { updateUserRecommendationPreferences(input: { preferredTopics: [ {id:\"1bf756c0-632f-49e8-9cce-324f38f4cc71\"}, {id:\"45f8e740-42e0-4f54-8363-21310a084f1f\"} ] }) { preferredTopics { id name } }}query Test2 { setupMomentSlate{ id headline recommendations { id corpusItem { id } } }}",
    "variables": null,
    "operationName": "PostmanUpdateUserRecommendationPreferences"
}'
```

### setupMomentSlate
```shell
curl --location --request POST 'https://recommendation-api.getpocket.dev' \
--header 'userId: 123456789' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": "query PostmanSetupMomentSlate { setupMomentSlate{ id headline recommendations(count: 100) { id corpusItem { id } } }}",
    "variables": null,
    "operationName": "PostmanSetupMomentSlate"
}'
```