### PR TITLE
Change setup moment corpus candidate set and corpus slate id

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -17,10 +17,9 @@ class SetupMomentDispatch:
     setup moment to RankingDispatch as soon as we want to include rankers or experimentation.
     """
 
-    SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID = 'deea0f06-9dc9-44a5-b864-fea4a4d0beb7'
     DISPLAY_NAME = 'Save an article you find interesting'
     SUB_HEADLINE = 'sub headline'
-    CORPUS_IDS = ['deea0f06-9dc9-44a5-b864-fea4a4d0beb7']
+    CORPUS_CANDIDATE_SET_IDS = ['57d544d6-0758-4cd1-a7b4-86f454c8eae8']
 
     def __init__(
             self,
@@ -31,7 +30,7 @@ class SetupMomentDispatch:
         self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
 
     async def get_ranked_corpus_slate(self, user_id: str, recommendation_count: int) -> CorpusSlateModel:
-        items = await self.corpus_client.get_corpus_items(self.CORPUS_IDS)
+        items = await self.corpus_client.get_corpus_items(self.CORPUS_CANDIDATE_SET_IDS)
 
         user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(user_id)
         if user_recommendation_preferences:
@@ -43,7 +42,7 @@ class SetupMomentDispatch:
         recommendations = [CorpusRecommendationModel(id=uuid.uuid4().hex, corpus_item=item) for item in items]
 
         return CorpusSlateModel(
-            id=self.SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID,
+            id=str(uuid.uuid4()),
             headline=self.DISPLAY_NAME,
             subheadline=self.SUB_HEADLINE,
             recommendations=recommendations,

--- a/tests/assets/json/corpus_candidate_sets.json
+++ b/tests/assets/json/corpus_candidate_sets.json
@@ -2,7 +2,7 @@
   [
     {
       "FeatureName": "id",
-      "ValueAsString": "deea0f06-9dc9-44a5-b864-fea4a4d0beb7"
+      "ValueAsString": "57d544d6-0758-4cd1-a7b4-86f454c8eae8"
     },
     {
       "FeatureName": "unloaded_at",

--- a/tests/unit/data_providers/test_corpus_feature_group_client.py
+++ b/tests/unit/data_providers/test_corpus_feature_group_client.py
@@ -32,7 +32,7 @@ class TestCorpusFeatureGroupClient:
         Test the case where the queried records exist in the Feature Group.
         """
         corpus_items = await self.client.get_corpus_items(
-            corpus_ids=[SetupMomentDispatch.SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID]
+            corpus_ids=SetupMomentDispatch.CORPUS_CANDIDATE_SET_IDS
         )
 
         # Assert corpus_items reflect the corpus_candidate_sets.json fixture data.


### PR DESCRIPTION
# Goal
1. Change the Setup Moment Corpus candidate set to the editorial selected content one created in [#92](https://github.com/Pocket/data-flows/pull/92).
2. Change the CorpusSlate id field from a static value to a random uuid, per decision in [#147](https://github.com/Pocket/spec/pull/147/files). (It was previously set to the candidate set id as an oversight.)

## QA
I confirmed the new record is available using the aws cli:
```shell
aws sagemaker-featurestore-runtime get-record --feature-group-name production-corpus-candidate-sets-v1 --record-identifier-value-as-string 57d544d6-0758-4cd1-a7b4-86f454c8eae8
```

## Reference

Ticket: https://getpocket.atlassian.net/browse/HS-82

Jira thread where decision was made to end the current experiment:
- https://pocket.slack.com/archives/C03AGDGJ1E0/p1657239584911799?thread_ts=1657206001.057069&cid=C03AGDGJ1E0

## Implementation Decisions
- `CorpusSlate.id` is not used or referenced anywhere yet, which is why we can easily make this change now.