### PR TITLE
Change default topics to Health & Fitness, Entertainment, Technology,…

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -20,10 +20,12 @@ class SetupMomentDispatch:
 
     DISPLAY_NAME = 'Save an article you find interesting'
     SUB_HEADLINE = 'sub headline'
-    # Health & Fitness, Entertainment, Business
-    DEFAULT_TOPICS = ['26a3efb4-0f82-415a-9f47-7893df85853f',
-                      'c6242e35-4ef7-494f-ae9f-51f95b836424',
-                      '1bf756c0-632f-49e8-9cce-324f38f4cc71']
+    DEFAULT_TOPICS = [
+        '26a3efb4-0f82-415a-9f47-7893df85853f',  # Health & Fitness
+        'c6242e35-4ef7-494f-ae9f-51f95b836424',  # Entertainment
+        '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
+        '7dc49254-686d-46e1-aa94-7ac3e7767f66',  # Travel
+    ]
 
     CORPUS_CANDIDATE_SET_IDS = ['57d544d6-0758-4cd1-a7b4-86f454c8eae8']
 

--- a/tests/assets/topics.py
+++ b/tests/assets/topics.py
@@ -71,11 +71,27 @@ entertainment_topic = TopicModel(
     page_type=PageType.topic_page
 )
 
+travel_topic = TopicModel(
+    id='7dc49254-686d-46e1-aa94-7ac3e7767f66',
+    corpus_topic_id='TRAVEL',
+    name='Trave',
+    display_name='Travel',
+    slug='Travel',
+    query='Travel',
+    curator_label='Travel',
+    is_displayed=True,
+    is_promoted=True,
+    page_type=PageType.topic_page
+)
+
 
 all_topic_fixtures = [
     business_topic,
     gaming_topic,
     technology_topic,
+    health_topic,
+    travel_topic,
+    entertainment_topic,
 ]
 
 

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 MockResponse = namedtuple('MockResponse', 'status')
 
 
-corpus_topics = [health_topic, business_topic, entertainment_topic, technology_topic, gaming_topic]
+corpus_topics = [health_topic, business_topic, entertainment_topic, technology_topic, gaming_topic, travel_topic]
 corpus_topic_ids = [t.corpus_topic_id for t in corpus_topics]
 topics_by_id = {t.id: t for t in corpus_topics}
 
@@ -138,5 +138,6 @@ class TestSetupMomentSlate(TestDynamoDBBase):
             # Assert that 10 (the default for count) corpus items are being returned.
             assert len(recs) == 10
             # Because the user doesn't have any preferred topics, default ones should be recommended.
-            assert {rec['corpusItem']['topic'] for rec in recs} == \
-                   {health_topic.corpus_topic_id, business_topic.corpus_topic_id, entertainment_topic.corpus_topic_id}
+            assert {rec['corpusItem']['topic'] for rec in recs} <= \
+                   {health_topic.corpus_topic_id, entertainment_topic.corpus_topic_id, technology_topic.corpus_topic_id,
+                    travel_topic.corpus_topic_id}


### PR DESCRIPTION
# Goal
Change default topics for setup moment to the ones suggested by Carolyn:

- Health & Fitness
- Entertainment
- Technology
- Travel

## Reference

Slack thread:
* https://pocket.slack.com/archives/C03AGDGJ1E0/p1657325245796399

Decision of topics by Carolyn:
> If I was going to select which topics to default to for this experiment/for the trio modal only, I'd recommend
> Health & Fitness
> Entertainment
> Technology
> Travel (as an extra category)
> (as I did above)