### PR TITLE
Pass hashed user id and guid into Snowplow user entity

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -10,6 +10,7 @@ from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_model import CorpusSlateModel
+from app.models.user import User
 from app.rankers.algorithms import rank_by_preferred_topics
 
 
@@ -42,14 +43,14 @@ class SetupMomentDispatch:
         self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
         self.slate_tracker = slate_tracker
 
-    async def get_ranked_corpus_slate(self, user_id: str, recommendation_count: int) -> CorpusSlateModel:
+    async def get_ranked_corpus_slate(self, user: User, recommendation_count: int) -> CorpusSlateModel:
         items = await self.corpus_client.get_corpus_items(self.CORPUS_CANDIDATE_SET_IDS)
 
-        user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(user_id)
+        user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(str(user.user_id))
         if user_recommendation_preferences and user_recommendation_preferences.preferred_topics:
             topics = user_recommendation_preferences.preferred_topics
         else:
-            logging.info(f'SetupMoment is unpersonalized for user {user_id} because no preferences were found.')
+            logging.info(f'SetupMoment is unpersonalized for user {user.user_id} because no preferences were found.')
             topics = await self.topic_provider.get_topics(self.DEFAULT_TOPICS)
 
         items = rank_by_preferred_topics(items, topics, recommendation_count)
@@ -63,7 +64,7 @@ class SetupMomentDispatch:
             recommendations=recommendations,
         )
 
-        await self.slate_tracker.track(corpus_slate, user_id=user_id)
+        await self.slate_tracker.track(corpus_slate, user=user)
 
         return corpus_slate
 

--- a/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
@@ -56,7 +56,9 @@ class SnowplowCorpusSlateTracker:
         )
 
     def _get_user_entity(self, user: User) -> SelfDescribingJson:
+        user_entity = {k: v for k, v in user.dict().items() if v is not None}
+
         return SelfDescribingJson(
             schema=self.snowplow_config.USER_SCHEMA,
-            data=user.dict(),
+            data=user_entity,
         )

--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -97,7 +97,7 @@ class Query(ObjectType):
             slate_tracker=slate_tracker,
             topic_provider=topic_provider,
         ).get_ranked_corpus_slate(
-            user_id=info.context.get('user_id'),
+            user=info.context['user'],
             recommendation_count=recommendation_count,
         )
 

--- a/app/graphql/user_middleware.py
+++ b/app/graphql/user_middleware.py
@@ -1,3 +1,6 @@
+from app.models.user import User
+
+
 class UserMiddleware(object):
     """
     This piece of middleware adds the pocket user id to the graphql resolver context
@@ -12,13 +15,21 @@ class UserMiddleware(object):
         since this application lives within Pocket's VPC we are trusting that the upstream caller's
         have validated the JWT token and only set the userId in the header if it was valid
 
+        List of all headers that are passed to services that sit behind the Pocket Graph:
+        @see https://github.com/Pocket/client-api/blob/main/api-docs/docs/headers.md
+
         Should we also want to do our own validation, the full JWT token also exists as 'token' in the header
         https://github.com/Pocket/client-api/blob/main/src/main.ts#L18-L26
         """
-        try:
-            info.context['user_id'] = info.context.get('request').headers.get('userId')
-        except AttributeError:
-            """No user id so let's explicitly set it to none"""
-            info.context['user_id'] = None
+        headers = info.context.get('request').headers
+
+        info.context['user_id'] = headers.get('userId')
+
+        info.context['user'] = User(
+            user_id=headers.get('userId'),
+            hashed_user_id=headers.get('encodedId'),
+            hashed_guid=headers.get('encodedGuid'),
+            guid=headers.get('guid'),
+        )
 
         return next(root, info, **args)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    """
+    Represents user and session identifiers in internal and encoded representation:
+    - user_id: integer user id for Pocket account. Not present on logged-out requests.
+    - hashed_user_id: hashed (encoded) user_id. Not present on logged-out requests.
+    - guid: integer identifier that is consistent across sessions.
+    - hashed_user_id: hashed (encoded) guid.
+    """
+
+    user_id: int = None
+    hashed_user_id: str = None
+    guid: int = None
+    hashed_guid: str = None

--- a/tests/functional/data_providers/test_snowplow_corpus_slate_tracker.py
+++ b/tests/functional/data_providers/test_snowplow_corpus_slate_tracker.py
@@ -4,20 +4,22 @@ from app.data_providers.snowplow.snowplow_corpus_slate_tracker import SnowplowCo
 # PyTest is not able to find fixtures in these files without importing them.
 from tests.mocks.snowplow import *
 from tests.mocks.corpus_slate_model import *
+from tests.mocks.user import *
 
 
-async def test_track_successful_response(snowplow_tracker, corpus_slate_10_business_recs, caplog):
+async def test_track_successful_response(snowplow_tracker, corpus_slate_10_business_recs, user_1, caplog):
     slate_tracker = SnowplowCorpusSlateTracker(snowplow_tracker, snowplow_config=SnowplowConfig())
-    await slate_tracker.track(corpus_slate_10_business_recs, user_id='1234')
+    await slate_tracker.track(corpus_slate_10_business_recs, user=user_1)
 
     # No warnings, errors, or critical log statements were created.
     assert not any(r for r in caplog.records if r.levelname in ('WARNING', 'ERROR', 'CRITICAL'))
 
 
-async def test_track_failure_response(snowplow_tracker_with_server_failure, corpus_slate_10_business_recs, caplog):
+async def test_track_failure_response(
+        snowplow_tracker_with_server_failure, corpus_slate_10_business_recs, user_1, caplog):
     slate_tracker = SnowplowCorpusSlateTracker(snowplow_tracker_with_server_failure, snowplow_config=SnowplowConfig())
     # Snowplow server errors don't cause an exception. Our service should continue to function independent of Snowplow.
-    await slate_tracker.track(corpus_slate_10_business_recs, user_id='1234')
+    await slate_tracker.track(corpus_slate_10_business_recs, user=user_1)
 
     # Assert that a 501 status code was logged.
     # TODO: We should change this level from 'warning' to 'error' in aio_snowplow_tracker.

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -16,6 +16,7 @@ from app.graphql.graphql_router import schema
 from app.main import app
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.topic import TopicModel
+from app.models.user import User
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 from tests.assets.topics import *
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
@@ -56,7 +57,12 @@ class TestSetupMomentSlate(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.client = Client(schema)
-        self.user_id = '123456789'
+        self.user = User(
+            user_id=1,
+            hashed_user_id='1-hashed',
+            guid=9876,
+            hashed_guid='9876-hashed'
+        )
 
         self.snowplow_micro = SnowplowMicroClient(config=SnowplowConfig())
         self.snowplow_micro.reset_snowplow_events()
@@ -68,7 +74,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
         mock_get_ranked_corpus_items.return_value = corpus_items_fixture
 
         preferred_topics = [technology_topic, gaming_topic]
-        preferences_fixture = _user_recommendation_preferences_fixture(self.user_id, preferred_topics)
+        preferences_fixture = _user_recommendation_preferences_fixture(str(self.user.user_id), preferred_topics)
         mock_fetch_user_recommendation_preferences.return_value = preferences_fixture
 
         with TestClient(app):
@@ -88,7 +94,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
                   }
                 }
                 ''',
-                context_value={'user_id': self.user_id},
+                context_value={'user': self.user},
                 executor=AsyncioExecutor())
 
             response = executed['data']['setupMomentSlate']
@@ -112,13 +118,14 @@ class TestSetupMomentSlate(TestDynamoDBBase):
     @patch.object(CorpusFeatureGroupClient, 'get_corpus_items')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
     @patch.object(TopicProvider, 'get_topics')
-    def test_default_count(self, mock_get_topics, mock_fetch_user_recommendation_preferences, mock_get_ranked_corpus_items):
+    def test_default_count(
+            self, mock_get_topics, mock_fetch_user_recommendation_preferences, mock_get_ranked_corpus_items):
         corpus_items_fixture = _corpus_items_fixture(n=100)
         mock_get_ranked_corpus_items.return_value = corpus_items_fixture
         default_recommendation_count = 10  # Number of recommendations that is expected to be returned by default.
 
         mock_fetch_user_recommendation_preferences.return_value = \
-            _user_recommendation_preferences_fixture(self.user_id, [])
+            _user_recommendation_preferences_fixture(str(self.user.user_id), [])
         mock_get_topics.return_value = _get_topics_fixture(SetupMomentDispatch.DEFAULT_TOPICS)
 
         with TestClient(app):
@@ -138,7 +145,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
                   }
                 }
                 ''',
-                context_value={'user_id': self.user_id},
+                context_value={'user': self.user},
                 executor=AsyncioExecutor())
 
             response = executed['data']['setupMomentSlate']
@@ -172,4 +179,4 @@ class TestSetupMomentSlate(TestDynamoDBBase):
             if context_data['schema'] == SnowplowConfig.CORPUS_SLATE_SCHEMA:
                 assert len(context_data['data']['recommendations']) == expected_recommendation_count
             elif context_data['schema'] == SnowplowConfig.USER_SCHEMA:
-                assert context_data['data']['user_id'] == int(self.user_id)
+                assert context_data['data']['user_id'] == int(self.user.user_id)

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -60,8 +60,6 @@ class TestSetupMomentSlate(TestDynamoDBBase):
         self.user = User(
             user_id=1,
             hashed_user_id='1-hashed',
-            guid=9876,
-            hashed_guid='9876-hashed'
         )
 
         self.snowplow_micro = SnowplowMicroClient(config=SnowplowConfig())

--- a/tests/mocks/user.py
+++ b/tests/mocks/user.py
@@ -1,0 +1,13 @@
+import pytest
+
+from app.models.user import User
+
+
+@pytest.fixture
+def user_1():
+    return User(
+        user_id=1,
+        hashed_user_id='1-hashed',
+        guid=9876,
+        hashed_guid='9876-hashed'
+    )


### PR DESCRIPTION
# Goal
The Dbt model that G created looks for `hashed_user_id` or `hashed_guid` to be passed into the Snowplow [user entity](https://console.snowplowanalytics.com/cf0fba6b-23b3-49a0-9d79-7ce18b8f9618/data-structures/7d9b5dadf4636e0818411c215770fd3090cb1c226480588fd72c237e89ca9895). Most client events only include the hashed user id, and it's therefore easier to join against these events if  the hashed_user_id is included.

## Todos
- [x] Test against Snowplow Mini
- [x] Clarify whether the FxA user id is passed into the userId header: https://github.com/Pocket/client-api/pull/246

## QA
1. Start RecommendationAPI locally using the `main Pocket-Dev` run configuration.
2. Perform a `setupMomentSlate` query:
    ```shell
    curl --location --request POST 'http://localhost:8000' \
    --header 'userId: 12345678' \
    --header 'encodedId: hashed-12345678' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "query": "query PostmanSetupMomentSlate { setupMomentSlate{ id headline recommendations(count: 10) { id corpusItem { id } } }}",
        "variables": null,
        "operationName": "PostmanSetupMomentSlate"
    }'
    ```

Expectations:
- [x] In Snowplow Mini, a User entity should be included with the provided user id and hashed user id.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-97

Pocket Graph headers doc:
* https://github.com/Pocket/client-api/blob/main/api-docs/docs/headers.md

Snowplow user entity:
* [user entity](https://console.snowplowanalytics.com/cf0fba6b-23b3-49a0-9d79-7ce18b8f9618/data-structures/7d9b5dadf4636e0818411c215770fd3090cb1c226480588fd72c237e89ca9895)

Related dbt PR:
* https://github.com/Pocket/dbt-snowflake/pull/242

## Implementation Decisions
- I created a `User` entity to hold user id values. The names correspond with the Snowplow user entity schema.