### PR TITLE
Add recommended_at attribute to corpus_slate entity

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import logging
 import uuid
 
@@ -59,6 +60,7 @@ class SetupMomentDispatch:
 
         corpus_slate = CorpusSlateModel(
             id=str(uuid.uuid4()),
+            recommended_at=datetime.now(tz=timezone.utc),
             headline=self.DISPLAY_NAME,
             subheadline=self.SUB_HEADLINE,
             recommendations=recommendations,

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -110,6 +110,7 @@ class RankingDispatch:
 
         return CorpusSlateModel(
             id=slate_id,
+            recommended_at=datetime.now(tz=timezone.utc),
             headline=corpus_slate_schema.displayName,
             subheadline=corpus_slate_schema.description,
             recommendations=recommendations,

--- a/app/data_providers/snowplow/config.py
+++ b/app/data_providers/snowplow/config.py
@@ -18,7 +18,7 @@ class SnowplowConfig:
 
     PROTOCOL: HttpProtocol = 'http' if ENV == ENV_LOCAL else 'https'
 
-    CORPUS_SLATE_SCHEMA = 'iglu:com.pocket/corpus_slate/jsonschema/1-0-1'
+    CORPUS_SLATE_SCHEMA = 'iglu:com.pocket/corpus_slate/jsonschema/2-0-0'
     USER_SCHEMA = 'iglu:com.pocket/user/jsonschema/1-0-0'
     OBJECT_UPDATE_SCHEMA = 'iglu:com.pocket/object_update/jsonschema/1-0-7'
 

--- a/app/data_providers/snowplow/config.py
+++ b/app/data_providers/snowplow/config.py
@@ -18,7 +18,7 @@ class SnowplowConfig:
 
     PROTOCOL: HttpProtocol = 'http' if ENV == ENV_LOCAL else 'https'
 
-    CORPUS_SLATE_SCHEMA = 'iglu:com.pocket/corpus_slate/jsonschema/2-0-0'
+    CORPUS_SLATE_SCHEMA = 'iglu:com.pocket/corpus_slate/jsonschema/2-0-1'
     USER_SCHEMA = 'iglu:com.pocket/user/jsonschema/1-0-0'
     OBJECT_UPDATE_SCHEMA = 'iglu:com.pocket/object_update/jsonschema/1-0-7'
 

--- a/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
@@ -1,6 +1,3 @@
-import datetime
-from typing import Optional
-
 from aws_xray_sdk.core import xray_recorder
 from aio_snowplow_tracker import Tracker, Subject, SelfDescribingJson
 
@@ -20,15 +17,17 @@ class SnowplowCorpusSlateTracker:
         self.snowplow_config = snowplow_config
 
     @xray_recorder.capture_async('data_providers.SnowplowCorpusSlateTracker.track')
-    async def track(self, corpus_slate: CorpusSlateModel, user: User, recommended_at: datetime.datetime = None):
-        if not recommended_at:
-            recommended_at = datetime.datetime.now()
-
+    async def track(self, corpus_slate: CorpusSlateModel, user: User):
+        """
+        Track the recommendation of a CorpusSlate in Snowplow.
+        :param corpus_slate: The slate that was recommended.
+        :param user: The user that the slate was recommended to.
+        """
         await self.tracker.track_self_describing_event(
             event_json=self._get_object_update_event(object='corpus_slate', trigger='corpus_slate_recommendation'),
             event_subject=self._get_subject(user),
             context=[
-                self._get_corpus_slate_entity(corpus_slate, recommended_at=recommended_at),
+                self._get_corpus_slate_entity(corpus_slate),
                 self._get_user_entity(user),
             ],
         )
@@ -42,16 +41,12 @@ class SnowplowCorpusSlateTracker:
             data={'object': object, 'trigger': trigger}
         )
 
-    def _get_corpus_slate_entity(
-            self,
-            corpus_slate: CorpusSlateModel,
-            recommended_at: datetime.datetime,
-    ) -> SelfDescribingJson:
+    def _get_corpus_slate_entity(self, corpus_slate: CorpusSlateModel) -> SelfDescribingJson:
         return SelfDescribingJson(
             schema=self.snowplow_config.CORPUS_SLATE_SCHEMA,
             data={
                 'corpus_slate_id': corpus_slate.id,
-                'recommended_at': recommended_at.isoformat(),
+                'recommended_at': corpus_slate.recommended_at.isoformat(),
                 'recommendations': [
                     {
                         'corpus_recommendation_id': recommendation.id,

--- a/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
@@ -46,7 +46,7 @@ class SnowplowCorpusSlateTracker:
             schema=self.snowplow_config.CORPUS_SLATE_SCHEMA,
             data={
                 'corpus_slate_id': corpus_slate.id,
-                'recommended_at': corpus_slate.recommended_at.isoformat(),
+                'recommended_at': int(corpus_slate.recommended_at.timestamp()),
                 'recommendations': [
                     {
                         'corpus_recommendation_id': recommendation.id,

--- a/app/models/corpus_slate_model.py
+++ b/app/models/corpus_slate_model.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel
@@ -11,6 +12,7 @@ class CorpusSlateModel(BaseModel):
     """
     id: str
     recommendations: List[CorpusRecommendationModel]
+    recommended_at: datetime  # UTC time when the slate was recommended
     headline: str
     subheadline: str = None
     more_link_url: str = None

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -95,6 +95,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
                 context_value={'user': self.user},
                 executor=AsyncioExecutor())
 
+            assert not executed.get('errors')
             response = executed['data']['setupMomentSlate']
             recs = response['recommendations']
             assert response['headline'] == 'Save an article you find interesting'
@@ -146,6 +147,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
                 context_value={'user': self.user},
                 executor=AsyncioExecutor())
 
+            assert not executed.get('errors')f
             response = executed['data']['setupMomentSlate']
             recs = response['recommendations']
 
@@ -176,5 +178,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
         for context_data in good_events[0]['event']['contexts']['data']:
             if context_data['schema'] == SnowplowConfig.CORPUS_SLATE_SCHEMA:
                 assert len(context_data['data']['recommendations']) == expected_recommendation_count
+                # recommended_at explicitly specifies that the timezone is UTC.
+                assert context_data['data']['recommended_at'].endswith('+00:00')
             elif context_data['schema'] == SnowplowConfig.USER_SCHEMA:
                 assert context_data['data']['user_id'] == int(self.user.user_id)

--- a/tests/functional/graphql/test_setup_moment_slate.py
+++ b/tests/functional/graphql/test_setup_moment_slate.py
@@ -147,7 +147,7 @@ class TestSetupMomentSlate(TestDynamoDBBase):
                 context_value={'user': self.user},
                 executor=AsyncioExecutor())
 
-            assert not executed.get('errors')f
+            assert not executed.get('errors')
             response = executed['data']['setupMomentSlate']
             recs = response['recommendations']
 

--- a/tests/mocks/corpus_slate_model.py
+++ b/tests/mocks/corpus_slate_model.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import uuid
 
 import pytest
@@ -11,6 +12,7 @@ from app.models.corpus_slate_model import CorpusSlateModel
 def corpus_slate_10_business_recs():
     return CorpusSlateModel(
         id=str(uuid.uuid4()),
+        recommended_at=datetime(2022, 7, 21, 14, 30, tzinfo=timezone.utc),
         headline="All your favorite stories",
         recommendations=[
             CorpusRecommendationModel(


### PR DESCRIPTION
# Goal
Add a `recommended_at` field to CorpusSlate that indicates the time at which the corpus slate was recommended. This implements https://github.com/Pocket/spec/pull/152.

## Deployment
- [x] The corpus_slate 2.0.0 Snowplow entity is deployed to production.
- [x] The Dbt model parses the Unix timestamp. https://github.com/Pocket/dbt-snowflake/pull/249

## Reference

Spec change:
* https://github.com/Pocket/spec/pull/152

Jira ticket:
* https://getpocket.atlassian.net/browse/HS-99
