### PR TITLE
Warn not error on missing item/slate dynamodb metrics

### DIFF
--- a/app/models/metrics/abstract_metrics_factory.py
+++ b/app/models/metrics/abstract_metrics_factory.py
@@ -52,7 +52,7 @@ class AbstractMetricsFactory(ABC):
         metrics = {k.split("/")[0]: self.parse_from_record(v) for k, v in metrics.items() if v is not None}
 
         if not metrics:
-            logging.error(f"No metrics for module {module_id} with keys={keys}")
+            logging.warn(f"No metrics for module {module_id} with keys={keys}")
 
         return metrics
 


### PR DESCRIPTION
# Goal

Stop flooding sentry with events for which there is no action.

<img width="1627" alt="Screen Shot 2022-07-27 at 9 31 22 AM" src="https://user-images.githubusercontent.com/13011/181301248-7637d589-4a69-4baf-84a7-8c106f370927.png">

