### PR TITLE
[HS-131] Write user preferences keyed on hashed user_id

### DIFF
--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -12,6 +12,10 @@ from app.models.user_recommendation_preferences import UserRecommendationPrefere
 
 
 class UserRecommendationPreferencesProvider:
+    """
+    Put or fetch user preferred topics in a Feature Group keyed on the integer user id.
+    """
+
     _FEATURE_GROUP_VERSION = 1
     _FEATURE_NAMES: List[str] = ['user_id', 'updated_at', 'preferred_topics']
 
@@ -117,4 +121,7 @@ class UserRecommendationPreferencesProvider:
 
 
 class UserRecommendationPreferencesProviderV2(UserRecommendationPreferencesProvider):
+    """
+    Put or fetch user preferred topics in a Feature Group keyed on the hashed user id.
+    """
     _FEATURE_GROUP_VERSION = 2

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -8,7 +8,8 @@ from aws_xray_sdk.core import xray_recorder
 from app import config
 from app.data_providers.topic_provider import TopicProvider
 from app.models.topic import TopicModel
-from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
+from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel, \
+    UserRecommendationPreferencesModelV2
 
 
 class UserRecommendationPreferencesProvider:
@@ -18,6 +19,7 @@ class UserRecommendationPreferencesProvider:
 
     _FEATURE_GROUP_VERSION = 1
     _FEATURE_NAMES: List[str] = ['user_id', 'updated_at', 'preferred_topics']
+    _FEATURE_ID_NAME: str = 'user_id'
 
     def __init__(self, aioboto3_session: aioboto3.session.Session, topic_provider: TopicProvider):
         self.aioboto3_session = aioboto3_session
@@ -93,7 +95,7 @@ class UserRecommendationPreferencesProvider:
         preferred_topics = json.loads(record['preferred_topics'])
 
         return UserRecommendationPreferencesModel(
-            user_id=record['user_id'],
+            user_id=record[self._FEATURE_ID_NAME],
             updated_at=dateutil.parser.isoparse(record['updated_at']),
             preferred_topics=await self.topic_provider.get_topics([t['id'] for t in preferred_topics])
         )
@@ -102,8 +104,8 @@ class UserRecommendationPreferencesProvider:
     def _feature_store_record_from_model(cls, model: UserRecommendationPreferencesModel) -> List[Dict[str, Any]]:
         return [
             {
-                'FeatureName': 'user_id',
-                'ValueAsString': model.user_id
+                'FeatureName': cls._FEATURE_ID_NAME,
+                'ValueAsString': getattr(model, cls._FEATURE_ID_NAME)
             },
             {
                 'FeatureName': 'updated_at',
@@ -120,8 +122,110 @@ class UserRecommendationPreferencesProvider:
         return {'id': topic.id}
 
 
-class UserRecommendationPreferencesProviderV2(UserRecommendationPreferencesProvider):
+class UserRecommendationPreferencesProviderV2:
     """
     Put or fetch user preferred topics in a Feature Group keyed on the hashed user id.
     """
     _FEATURE_GROUP_VERSION = 2
+    _FEATURE_NAMES: List[str] = ['hashed_user_id', 'updated_at', 'preferred_topics']
+    _FEATURE_ID_NAME: str = 'hashed_user_id'
+
+    def __init__(self, aioboto3_session: aioboto3.session.Session, topic_provider: TopicProvider):
+        self.aioboto3_session = aioboto3_session
+        self.topic_provider = topic_provider
+
+    async def put(self, model: UserRecommendationPreferencesModelV2):
+        """
+        Inserts or updates user recommendation preferences.
+        :param model:
+        """
+        await self._put_feature_store_record(model)
+
+    async def fetch(self, hashed_user_id: str) -> Optional[UserRecommendationPreferencesModelV2]:
+        """
+        Gets user recommendation preferences for a given user id.
+        :param hashed_user_id:
+        :return:
+        """
+        if hashed_user_id is None:
+            raise ValueError('hashed_user_id is required in UserRecommendationPreferencesProvider.fetch')
+
+        feature_store_record = await self._get_feature_store_record(hashed_user_id)
+        if not feature_store_record:
+            return None
+
+        model = await self._model_from_feature_store_record(feature_store_record)
+        return model
+
+    @classmethod
+    def get_feature_group_name(cls):
+        return f'{config.ENV}-user-recommendation-preferences-v{cls._FEATURE_GROUP_VERSION}'
+
+    @xray_recorder.capture_async('UserRecommendationPreferencesProviderV2._put_feature_store_record')
+    async def _put_feature_store_record(self, model: UserRecommendationPreferencesModelV2):
+        """
+        Writes a record to the feature group.
+        :param model:
+        """
+        async with self.aioboto3_session.client('sagemaker-featurestore-runtime') as featurestore:
+            await featurestore.put_record(
+                FeatureGroupName=self.get_feature_group_name(),
+                Record=self._feature_store_record_from_model(model)
+            )
+
+    @xray_recorder.capture_async('UserRecommendationPreferencesProviderV2._get_feature_store_record')
+    async def _get_feature_store_record(self, hashed_user_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Queries user recommendation preferences from the Feature Group.
+
+        :param hashed_user_id:
+        :return: List with all items that should be filtered from slates/lineups returned by the recommendation-api
+                 for the user corresponding to User.id (hashed user id)
+        """
+
+        async with self.aioboto3_session.client('sagemaker-featurestore-runtime') as featurestore:
+            record = await featurestore.get_record(
+                FeatureGroupName=self.get_feature_group_name(),
+                RecordIdentifierValueAsString=str(hashed_user_id),
+                FeatureNames=self._FEATURE_NAMES
+            )
+
+        if 'Record' not in record:
+            # We do not have any preferences yet for this hashed_user_id.
+            return None
+
+        # Map list of features to dict.
+        return {feature['FeatureName']: feature['ValueAsString'] for feature in record['Record']}
+
+    @xray_recorder.capture_async('UserRecommendationPreferencesProviderV2._model_from_feature_store_record')
+    async def _model_from_feature_store_record(
+        self, record: Optional[Dict[str, Any]],
+    ) -> UserRecommendationPreferencesModelV2:
+        preferred_topics = json.loads(record['preferred_topics'])
+
+        return UserRecommendationPreferencesModelV2(
+            hashed_user_id=record[self._FEATURE_ID_NAME],
+            updated_at=dateutil.parser.isoparse(record['updated_at']),
+            preferred_topics=await self.topic_provider.get_topics([t['id'] for t in preferred_topics])
+        )
+
+    @classmethod
+    def _feature_store_record_from_model(cls, model: UserRecommendationPreferencesModelV2) -> List[Dict[str, Any]]:
+        return [
+            {
+                'FeatureName': cls._FEATURE_ID_NAME,
+                'ValueAsString': getattr(model, cls._FEATURE_ID_NAME)
+            },
+            {
+                'FeatureName': 'updated_at',
+                'ValueAsString': model.updated_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+            },
+            {
+                'FeatureName': 'preferred_topics',
+                'ValueAsString': json.dumps([cls._topic_feature_from_topic(t) for t in model.preferred_topics])
+            },
+        ]
+
+    @classmethod
+    def _topic_feature_from_topic(cls, topic: TopicModel) -> Dict[str, str]:
+        return {'id': topic.id}

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -114,3 +114,7 @@ class UserRecommendationPreferencesProvider:
     @classmethod
     def _topic_feature_from_topic(cls, topic: TopicModel) -> Dict[str, str]:
         return {'id': topic.id}
+
+
+class UserRecommendationPreferencesProviderV2(UserRecommendationPreferencesProvider):
+    _FEATURE_GROUP_VERSION = 2

--- a/app/graphql/update_user_recommendation_preferences_mutation.py
+++ b/app/graphql/update_user_recommendation_preferences_mutation.py
@@ -12,7 +12,10 @@ from app.data_providers.user_recommendation_preferences_provider import (
 from app.graphql.topic import Topic
 from app.graphql.update_user_recommendation_preferences_input import UpdateUserRecommendationPreferencesInput
 from app.models.user import User
-from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
+from app.models.user_recommendation_preferences import (
+    UserRecommendationPreferencesModel,
+    UserRecommendationPreferencesModelV2,
+)
 
 
 class UpdateUserRecommendationPreferences(graphene.Mutation):
@@ -45,8 +48,8 @@ class UpdateUserRecommendationPreferences(graphene.Mutation):
             preferred_topics=preferred_topics
         )
 
-        model_v2 = UserRecommendationPreferencesModel(
-            user_id=user.hashed_user_id,
+        model_v2 = UserRecommendationPreferencesModelV2(
+            hashed_user_id=user.hashed_user_id,
             updated_at=datetime.datetime.utcnow(),
             preferred_topics=preferred_topics
         )

--- a/app/graphql/update_user_recommendation_preferences_mutation.py
+++ b/app/graphql/update_user_recommendation_preferences_mutation.py
@@ -11,6 +11,7 @@ from app.data_providers.user_recommendation_preferences_provider import (
 )
 from app.graphql.topic import Topic
 from app.graphql.update_user_recommendation_preferences_input import UpdateUserRecommendationPreferencesInput
+from app.models.user import User
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 
 
@@ -36,15 +37,16 @@ class UpdateUserRecommendationPreferences(graphene.Mutation):
         )
 
         preferred_topics = await topic_provider.get_topics([t.id for t in input.preferredTopics])
+        user: User = info.context['user']
 
         model = UserRecommendationPreferencesModel(
-            user_id=info.context.get('user_id'),
+            user_id=user.user_id,  # Integer user id
             updated_at=datetime.datetime.utcnow(),
             preferred_topics=preferred_topics
         )
 
         model_v2 = UserRecommendationPreferencesModel(
-            user_id=info.context['user'].hashed_user_id,
+            user_id=user.hashed_user_id,
             updated_at=datetime.datetime.utcnow(),
             preferred_topics=preferred_topics
         )

--- a/app/models/user_recommendation_preferences.py
+++ b/app/models/user_recommendation_preferences.py
@@ -13,6 +13,6 @@ class UserRecommendationPreferencesModel(BaseModel):
 
 
 class UserRecommendationPreferencesModelV2(BaseModel):
-    hashed_user_id: str  # Only difference between v1 and v2 is that this column is renamed
+    hashed_user_id: str  # The difference between v1 and v2 is that this column is renamed to store the hashed user id.
     updated_at: datetime.datetime
     preferred_topics: List[TopicModel]

--- a/app/models/user_recommendation_preferences.py
+++ b/app/models/user_recommendation_preferences.py
@@ -10,3 +10,9 @@ class UserRecommendationPreferencesModel(BaseModel):
     user_id: str
     updated_at: datetime.datetime
     preferred_topics: List[TopicModel]
+
+
+class UserRecommendationPreferencesModelV2(BaseModel):
+    hashed_user_id: str  # Only difference between v1 and v2 is that this column is renamed
+    updated_at: datetime.datetime
+    preferred_topics: List[TopicModel]

--- a/tests/assets/json/user_recommendation_preferences_v2.json
+++ b/tests/assets/json/user_recommendation_preferences_v2.json
@@ -1,0 +1,16 @@
+[
+  [
+    {
+      "FeatureName": "user_id",
+      "ValueAsString": "aaaaaaaaaaaaaaa123"
+    },
+    {
+      "FeatureName": "updated_at",
+      "ValueAsString": "2022-06-07T23:00:48Z"
+    },
+    {
+      "FeatureName": "preferred_topics",
+      "ValueAsString": "[{\"id\": \"1bf756c0-632f-49e8-9cce-324f38f4cc71\"}, {\"id\": \"25c716f1-e1b2-43db-bf52-1a5553d9fb74\"}]"
+    }
+  ]
+]

--- a/tests/assets/json/user_recommendation_preferences_v2.json
+++ b/tests/assets/json/user_recommendation_preferences_v2.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "FeatureName": "user_id",
+      "FeatureName": "hashed_user_id",
       "ValueAsString": "aaaaaaaaaaaaaaa123"
     },
     {

--- a/tests/functional/graphql/test_update_user_recommendation_preferences.py
+++ b/tests/functional/graphql/test_update_user_recommendation_preferences.py
@@ -2,9 +2,13 @@ from graphql.execution.executors.asyncio import AsyncioExecutor
 from graphene.test import Client
 from fastapi.testclient import TestClient
 
-from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
+from app.data_providers.user_recommendation_preferences_provider import (
+    UserRecommendationPreferencesProvider,
+    UserRecommendationPreferencesProviderV2,
+)
 from app.graphql.graphql_router import schema
 from app.main import app
+from app.models.user import User
 from tests.assets.topics import populate_topics, technology_topic, business_topic
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
@@ -21,11 +25,16 @@ class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
         await super().asyncSetUp()
         populate_topics(self.metadata_table)
         self.client = Client(schema)
+        self.user = User(
+            user_id=1,
+            hashed_user_id='1-hashed',
+        )
+
 
     @patch.object(UserRecommendationPreferencesProvider, 'put')
-    def test_update_user_recommendation_preferences(self, mock_data_provider_put):
+    @patch.object(UserRecommendationPreferencesProviderV2, 'put')
+    def test_update_user_recommendation_preferences(self, mock_data_provider_put_v2, mock_data_provider_put):
         topics = populate_topics(self.metadata_table)
-        user_id = 'johnjacobjingleheimerschmidt'
 
         with TestClient(app):
             executed = self.client.execute(
@@ -47,7 +56,7 @@ class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
                         ]
                     }
                 },
-                context_value={'user_id': user_id},
+                context_value={'user_id': self.user.user_id, 'user': self.user},
                 executor=AsyncioExecutor())
 
             response = executed.get('data').get('updateUserRecommendationPreferences')

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider.py
@@ -26,6 +26,8 @@ class TestUserRecommendationPreferencesProvider:
             records_json_path=os.path.join(ROOT_DIR, 'tests/assets/json/user_recommendation_preferences.json')
         )
 
+        self.existing_user_id = '12341234'  # Defined in the above JSON fixture
+
         # This is the client that's under test.
         self.client = UserRecommendationPreferencesProvider(
             aioboto3_session=self.feature_store_mock.aioboto3,
@@ -59,10 +61,10 @@ class TestUserRecommendationPreferencesProvider:
         """
         Test the case where the queried records exist in the Feature Group.
         """
-        model = await self.client.fetch('12341234')
+        model = await self.client.fetch(self.existing_user_id)
 
         # Assert model matches fixture data in user_recommendation_preferences.json
-        assert model.user_id == '12341234'
+        assert model.user_id == self.existing_user_id
         assert model.preferred_topics == [business_topic, technology_topic]
 
     async def test_fetch_non_existing_user(self):

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider_v2.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider_v2.py
@@ -1,3 +1,5 @@
+import datetime
+import json
 import os
 from unittest.mock import MagicMock
 
@@ -6,21 +8,21 @@ from aws_xray_sdk import global_sdk_config
 
 from app.config import ROOT_DIR
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProviderV2
+from app.models.user_recommendation_preferences import UserRecommendationPreferencesModelV2
+from tests.assets.topics import technology_topic, business_topic
 from tests.mocks.feature_store_mock import FeatureStoreMock
 from tests.mocks.topic_provider import MockTopicProvider
-from tests.unit.data_providers.test_user_recommendation_preferences_provider import \
-    TestUserRecommendationPreferencesProvider
 
 
 @pytest.mark.asyncio  # This pytest-asyncio decorator allows us to use an async side_effect
-class TestUserRecommendationPreferencesProviderV2(TestUserRecommendationPreferencesProvider):
+class TestUserRecommendationPreferencesProviderV2:
 
     def setup(self):
         global_sdk_config.set_sdk_enabled(False)
 
         self.feature_store_mock = FeatureStoreMock(
             feature_group_name=UserRecommendationPreferencesProviderV2.get_feature_group_name(),
-            identifier_feature_name='user_id',
+            identifier_feature_name='hashed_user_id',
             records_json_path=os.path.join(ROOT_DIR, 'tests/assets/json/user_recommendation_preferences_v2.json')
         )
 
@@ -34,3 +36,45 @@ class TestUserRecommendationPreferencesProviderV2(TestUserRecommendationPreferen
 
     async def test_feature_group_name(self):
         assert self.client.get_feature_group_name().endswith('recommendation-preferences-v2')
+
+    async def test_put(self):
+        """
+        Test the case where the queried records exist in the Feature Group.
+        """
+        model = UserRecommendationPreferencesModelV2(
+            hashed_user_id='user-123',
+            updated_at=datetime.datetime(2022, 6, 9, 12, 30),
+            preferred_topics=[technology_topic],
+        )
+
+        await self.client.put(model)
+
+        # Assert corpus_items reflect the corpus_candidate_sets.json fixture data.
+        record = self.feature_store_mock.records_by_id[model.hashed_user_id]
+        features = {feature['FeatureName']: feature['ValueAsString'] for feature in record}
+
+        assert features['hashed_user_id'] == model.hashed_user_id
+        assert features['updated_at'] == '2022-06-09T12:30:00Z'
+
+        preferred_topics_feature = json.loads(features['preferred_topics'])
+        assert len(preferred_topics_feature) == 1
+        assert preferred_topics_feature[0]['id'] == model.preferred_topics[0].id
+
+    async def test_fetch(self):
+        """
+        Test the case where the queried records exist in the Feature Group.
+        """
+        model = await self.client.fetch(self.existing_user_id)
+
+        # Assert model matches fixture data in user_recommendation_preferences.json
+        assert model.hashed_user_id == self.existing_user_id
+        assert model.preferred_topics == [business_topic, technology_topic]
+
+    async def test_fetch_non_existing_user(self):
+        """
+        Test the case where the queried records exist in the Feature Group.
+        """
+        model = await self.client.fetch('9999')
+
+        # Assert model matches fixture data in user_recommendation_preferences.json
+        assert model is None

--- a/tests/unit/data_providers/test_user_recommendation_preferences_provider_v2.py
+++ b/tests/unit/data_providers/test_user_recommendation_preferences_provider_v2.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from aws_xray_sdk import global_sdk_config
+
+from app.config import ROOT_DIR
+from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProviderV2
+from tests.mocks.feature_store_mock import FeatureStoreMock
+from tests.mocks.topic_provider import MockTopicProvider
+from tests.unit.data_providers.test_user_recommendation_preferences_provider import \
+    TestUserRecommendationPreferencesProvider
+
+
+@pytest.mark.asyncio  # This pytest-asyncio decorator allows us to use an async side_effect
+class TestUserRecommendationPreferencesProviderV2(TestUserRecommendationPreferencesProvider):
+
+    def setup(self):
+        global_sdk_config.set_sdk_enabled(False)
+
+        self.feature_store_mock = FeatureStoreMock(
+            feature_group_name=UserRecommendationPreferencesProviderV2.get_feature_group_name(),
+            identifier_feature_name='user_id',
+            records_json_path=os.path.join(ROOT_DIR, 'tests/assets/json/user_recommendation_preferences_v2.json')
+        )
+
+        self.existing_user_id = 'aaaaaaaaaaaaaaa123'  # Defined in the above JSON fixture
+
+        # This is the client that's under test.
+        self.client = UserRecommendationPreferencesProviderV2(
+            aioboto3_session=self.feature_store_mock.aioboto3,
+            topic_provider=MockTopicProvider(aioboto3_session=MagicMock())
+        )
+
+    async def test_feature_group_name(self):
+        assert self.client.get_feature_group_name().endswith('recommendation-preferences-v2')


### PR DESCRIPTION
# Goal
To allow clients to query a User's recommendation preferences, we want to extend the GraphQL User with a `recommendationPreferences` field. https://github.com/Pocket/spec/pull/159 The GraphQL `User.id` field is the _hashed_ user id, while our feature group currently keys preferences on the _integer_ user id (which is deprecated). To extend the GraphQL User object we need to key these preferences on the _hashed_ user id.

Phases:
1. **(This PR) Write preferences to two Feature Groups, keyed respectively on integer user id and hashed user id. [HS-131](https://getpocket.atlassian.net/browse/HS-131)**
2. Backfill from feature group v1 to v2. [HS-132](https://getpocket.atlassian.net/browse/HS-132)
3. Recommendation API reads from v2 keyed on hashed user_id. [HS-133](https://getpocket.atlassian.net/browse/HS-133)
4. Remove writes to v1 feature group to decommission it. [HS-134](https://getpocket.atlassian.net/browse/HS-134)

## Deployment
- [x] Create `development-user-recommendation-preferences-v2`
- [x] Create `production-user-recommendation-preferences-v2`

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-131

Slack:
- [Thread about whether the integer user id is deprecated](https://pocket.slack.com/archives/C02JZ4TRF0S/p1659979324866529?thread_ts=1659650863.471869&cid=C02JZ4TRF0S)

## Implementation Decisions
- The GraphQL User object and Snowplow user entity have a different meaning for what a "user id" is, which leads to ambiguity in systems that connect to both.
    - My understanding is that using the integer user id is deprecated:
        > My primary take away is that if we are building something new we should use hashed user id and use it as a string key field.
    - I've continued to refer as "hashed_user_id" to the encoded id that GraphQL uses for `User.id`, because this is how we refer to this identifier in practice today.
    - I tried to disambiguate by adding comments.

## Feature Group schema
The schema between v1 and v2 is unchanged, but the meaning of `user_id` has changed from the integer user id to the hashed user id.
```python
[
    {
        # Hashed user id, corresponding in GraphQL to User.id
        "name": "user_id",
        "type": "string"
    },
    {
        "name": "updated_at",
        "type": "datetime"
    },
    {
        # JSON array of topics, e.g. [{"id":"1bf756c0-632f-49e8-9cce-324f38f4cc71"}, {"id":"45f8e740-42e0-4f54-8363-21310a084f1f"}]
        "name": "preferred_topics",
        "type": "string"
    },
]
```

## QA
1. Get your test account user id and hashed/encoded user id.
2. Connect to the Development VPN.
3. Run a query to update preferred topics:
    ```shell
    curl --location --request POST 'https://recommendation-api.getpocket.dev' \
    --header 'userId: put-your-integer-user-id-here' \
    --header 'encodedId: put-your-hashed-user-id-here' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "query": "mutation PostmanUpdateUserRecommendationPreferences { updateUserRecommendationPreferences(input: { preferredTopics: [ {id:\"1bf756c0-632f-49e8-9cce-324f38f4cc71\"}, {id:\"45f8e740-42e0-4f54-8363-21310a084f1f\"} ] }) { preferredTopics { id name } }}",
        "variables": null,
        "operationName": "PostmanUpdateUserRecommendationPreferences"
    }'
    ```
4. Query the v1 feature group in Athena:
    ```sql
    SELECT * FROM "sagemaker_featurestore"."development-user-recommendation-preferences-v1-1654826050" limit 10;
    ```
5. Query the v2 feature group in Athena:
    ```sql
    SELECT * FROM "sagemaker_featurestore"."development-user-recommendation-preferences-v2-1659991605" limit 10;
    ```

### QA expectations
- [x] The request successfully returned the two preferred topic ids and names.
- [x] The v1 feature group should have an updated record for the given integer user id
- [x] The v2 feature group should have an updated record for the given hashed user id