### PR TITLE
feat(metrics): Fetch Corpus engagement metrics

### DIFF
--- a/app/data_providers/corpus_metrics_provider.py
+++ b/app/data_providers/corpus_metrics_provider.py
@@ -1,4 +1,3 @@
-import logging
 from asyncio import gather
 from datetime import datetime
 from typing import List, Dict
@@ -7,11 +6,10 @@ import aioboto3
 from aws_xray_sdk.core import xray_recorder
 
 from app import config
-from app.data_providers.util.feature_store import FeatureStoreRecordType, BATCH_GET_RECORD_MAX_ITEMS
+from app.data_providers.util.feature_store import FeatureStoreRecordType, BATCH_GET_RECORD_MAX_ITEMS, \
+    feature_store_record_to_dict
 from app.data_providers.util.iteration import chunks
 from app.models.metrics.corpus_metrics_model import CorpusMetricsModel, CorpusMetricsSegmentModel
-from app.models.metrics.firefox_new_tab_metrics_model import FirefoxNewTabMetricsModel
-from app.models.metrics.metrics_model import MetricsModel
 from app.models.surface import Surface
 
 
@@ -35,21 +33,36 @@ class CorpusMetricsProvider():
     def __init__(self, aioboto3_session: aioboto3.session.Session = None):
         self.aioboto3_session = aioboto3_session if aioboto3_session else aioboto3.Session()
 
+    async def fetch_by_corpus_item_ids(
+        self,
+        surface: Surface,
+        corpus_slate_config_id: str,
+        corpus_item_ids: List[str],
+    ) -> Dict[str, CorpusMetricsModel]:
+        """
+        Get corpus item engagement metrics for a given surface and slate config.
+        :param surface:
+        :param corpus_slate_config_id:
+        :param corpus_item_ids:
+        :return: The metrics are returned keyed on corpus_item_id. If no metrics are available keys will be missing.
+        """
+        metrics = await self.fetch([CorpusMetricsSegmentModel(
+            surface=surface,
+            corpus_slate_config_id=corpus_slate_config_id,
+            corpus_item_id=corpus_item_id,
+        ) for corpus_item_id in corpus_item_ids])
+
+        return {metric.segment.corpus_item_id: metric for metric in metrics}
+
     async def fetch(self, segments: List[CorpusMetricsSegmentModel]) -> List[CorpusMetricsModel]:
         """
         Get engagement metrics for Corpus Recommendations.
         :param segments: Segments of metrics to query.
         :return: List of metric models, not necessarily in the same order as the input.
         """
-        keys = map(self._format_key, segments)
+        keys = list(map(self._format_key, segments))
 
-        metrics = await self._query_metrics(keys)
-
-        # Convert from dict to Pydantic model
-        parsed_metrics = [self._parse_from_record(m) for m in metrics]
-        parsed_metrics_by_id = {m.id: m for m in parsed_metrics}
-
-        return parsed_metrics_by_id
+        return await self._query_metrics(keys)
 
     @classmethod
     def get_feature_group_name(cls):
@@ -64,29 +77,18 @@ class CorpusMetricsProvider():
         """
         return '/'.join([segment.surface, segment.corpus_slate_config_id, segment.corpus_item_id])
 
-    def _parse_from_record(self, record: FeatureStoreRecordType) -> CorpusMetricsModel:
+    @staticmethod
+    def _parse_from_record(record: FeatureStoreRecordType) -> CorpusMetricsModel:
         """
         Converts a FeatureGroup record to a Pydantic CorpusMetricsModel object
         :param record: dictionary containing all required keys for FirefoxNewTabMetricsModel
         :return: Parsed CorpusMetricsModel
         """
-        # Pydantic model uses lowercase keys.
-        return CorpusMetricsModel(
-            segment=CorpusMetricsSegmentModel(
-                surface=record['SURFACE'],
-                corpus_slate_config_id=record['CORPUS_SLATE_CONFIG_ID'],
-                corpus_item_id=record['CORPUS_ITEM_ID'],
-            ),
-            updated_at=datetime.fromisoformat(record['UPDATED_AT']),
-            trailing_1_day_opens=record['TRAILING_1_DAY_OPENS'],
-            trailing_1_day_impressions=record['TRAILING_1_DAY_IMPRESSIONS'],
-            trailing_7_day_opens=record['TRAILING_7_DAY_OPENS'],
-            trailing_7_day_impressions=record['TRAILING_7_DAY_IMPRESSIONS'],
-            trailing_14_day_opens=record['TRAILING_14_DAY_OPENS'],
-            trailing_14_day_impressions=record['TRAILING_14_DAY_IMPRESSIONS'],
-            trailing_28_day_opens=record['TRAILING_28_DAY_OPENS'],
-            trailing_28_day_impressions=record['TRAILING_28_DAY_IMPRESSIONS'],
-        )
+        record_dict = feature_store_record_to_dict(record, lowercase_names=True)
+        segment_dict = {k: record_dict[k] for k in CorpusMetricsSegmentModel.__fields__.keys()}
+        metrics_model_dict = dict({'segment': segment_dict}, **record_dict)
+
+        return CorpusMetricsModel.parse_obj(metrics_model_dict)
 
     @xray_recorder.capture_async('CorpusMetricsProvider._query_metrics')
     async def _query_metrics(self, metrics_keys: List[str]) -> List[FeatureStoreRecordType]:

--- a/app/data_providers/corpus_metrics_provider.py
+++ b/app/data_providers/corpus_metrics_provider.py
@@ -1,0 +1,122 @@
+import logging
+from asyncio import gather
+from datetime import datetime
+from typing import List, Dict
+
+import aioboto3
+from aws_xray_sdk.core import xray_recorder
+
+from app import config
+from app.data_providers.util.feature_store import FeatureStoreRecordType, BATCH_GET_RECORD_MAX_ITEMS
+from app.data_providers.util.iteration import chunks
+from app.models.metrics.corpus_metrics_model import CorpusMetricsModel, CorpusMetricsSegmentModel
+from app.models.metrics.firefox_new_tab_metrics_model import FirefoxNewTabMetricsModel
+from app.models.metrics.metrics_model import MetricsModel
+from app.models.surface import Surface
+
+
+class CorpusMetricsProvider():
+    _FEATURE_GROUP_VERSION: int = 1
+    _FEATURE_NAMES: List[str] = [
+        'UPDATED_AT',
+        'SURFACE',
+        'CORPUS_SLATE_CONFIG_ID'
+        'CORPUS_ITEM_ID'
+        'TRAILING_1_DAY_OPENS',
+        'TRAILING_1_DAY_IMPRESSIONS',
+        'TRAILING_7_DAY_OPENS',
+        'TRAILING_7_DAY_IMPRESSIONS',
+        'TRAILING_14_DAY_OPENS',
+        'TRAILING_14_DAY_IMPRESSIONS',
+        'TRAILING_28_DAY_OPENS',
+        'TRAILING_28_DAY_IMPRESSIONS',
+    ]
+
+    def __init__(self, aioboto3_session: aioboto3.session.Session = None):
+        self.aioboto3_session = aioboto3_session if aioboto3_session else aioboto3.Session()
+
+    async def fetch(self, segments: List[CorpusMetricsSegmentModel]) -> List[CorpusMetricsModel]:
+        """
+        Get engagement metrics for Corpus Recommendations.
+        :param segments: Segments of metrics to query.
+        :return: List of metric models, not necessarily in the same order as the input.
+        """
+        keys = map(self._format_key, segments)
+
+        metrics = await self._query_metrics(keys)
+
+        # Convert from dict to Pydantic model
+        parsed_metrics = [self._parse_from_record(m) for m in metrics]
+        parsed_metrics_by_id = {m.id: m for m in parsed_metrics}
+
+        return parsed_metrics_by_id
+
+    @classmethod
+    def get_feature_group_name(cls):
+        return f'{config.ENV}-corpus-engagement-v{cls._FEATURE_GROUP_VERSION}'
+
+    @staticmethod
+    def _format_key(segment: CorpusMetricsSegmentModel) -> str:
+        """
+        Formats the Feature Group key that identifies a given segment
+        :param segment:
+        :return:
+        """
+        return '/'.join([segment.surface, segment.corpus_slate_config_id, segment.corpus_item_id])
+
+    def _parse_from_record(self, record: FeatureStoreRecordType) -> CorpusMetricsModel:
+        """
+        Converts a FeatureGroup record to a Pydantic CorpusMetricsModel object
+        :param record: dictionary containing all required keys for FirefoxNewTabMetricsModel
+        :return: Parsed CorpusMetricsModel
+        """
+        # Pydantic model uses lowercase keys.
+        return CorpusMetricsModel(
+            segment=CorpusMetricsSegmentModel(
+                surface=record['SURFACE'],
+                corpus_slate_config_id=record['CORPUS_SLATE_CONFIG_ID'],
+                corpus_item_id=record['CORPUS_ITEM_ID'],
+            ),
+            updated_at=datetime.fromisoformat(record['UPDATED_AT']),
+            trailing_1_day_opens=record['TRAILING_1_DAY_OPENS'],
+            trailing_1_day_impressions=record['TRAILING_1_DAY_IMPRESSIONS'],
+            trailing_7_day_opens=record['TRAILING_7_DAY_OPENS'],
+            trailing_7_day_impressions=record['TRAILING_7_DAY_IMPRESSIONS'],
+            trailing_14_day_opens=record['TRAILING_14_DAY_OPENS'],
+            trailing_14_day_impressions=record['TRAILING_14_DAY_IMPRESSIONS'],
+            trailing_28_day_opens=record['TRAILING_28_DAY_OPENS'],
+            trailing_28_day_impressions=record['TRAILING_28_DAY_IMPRESSIONS'],
+        )
+
+    @xray_recorder.capture_async('CorpusMetricsProvider._query_metrics')
+    async def _query_metrics(self, metrics_keys: List[str]) -> List[FeatureStoreRecordType]:
+        """
+        Queries metrics from the Feature Group.
+
+        :param metrics_keys: Feature record IDs to query
+        :return: List with all metrics that were successfully queried from the Feature Store.
+                 If metrics are missing from the output that means the feature group did not find a match, probably
+                 because the recommendation is too recent.
+        """
+        records = []
+
+        async with self.aioboto3_session.client('sagemaker-featurestore-runtime') as featurestore:
+            promises = [featurestore.batch_get_record(
+                Identifiers=[
+                    {
+                        'FeatureGroupName': self.get_feature_group_name(),
+                        'RecordIdentifiersValueAsString': metrics_key_chunk,
+                        'FeatureNames': self._FEATURE_NAMES
+                    },
+                ]
+            ) for metrics_key_chunk in chunks(metrics_keys, BATCH_GET_RECORD_MAX_ITEMS)]
+
+            responses = await gather(*promises)
+
+            for response in responses:
+                # If FeatureStore can't find an ID, it returns a 200 response without a record.
+                record = response.get('Record')
+                if record:
+                    records.append(record)
+
+        return records

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -69,7 +69,7 @@ class SetupMomentDispatch:
         items = items[:recommendation_count]
 
         # TODO: Thompson sampling is applied here for demonstration.
-        metrics = self.metrics_provider.fetch_by_corpus_item_ids(
+        metrics = await self.metrics_provider.fetch_by_corpus_item_ids(
             Surface.SETUP_MOMENT, self.corpus_slate_config.id, [item.id for item in items])
         items = thompson_sampling_28day(recs=items, metrics=metrics)
 

--- a/app/data_providers/util/feature_store.py
+++ b/app/data_providers/util/feature_store.py
@@ -1,0 +1,6 @@
+
+# Unfortunately boto3 doesn't use types for feature store records at the moment, so we define one ourselves.
+FeatureStoreRecordType = List[Dict[str, str]]
+
+
+BATCH_GET_RECORD_MAX_ITEMS = 10

--- a/app/data_providers/util/feature_store.py
+++ b/app/data_providers/util/feature_store.py
@@ -1,6 +1,25 @@
 
 # Unfortunately boto3 doesn't use types for feature store records at the moment, so we define one ourselves.
+from typing import List, Dict
+
 FeatureStoreRecordType = List[Dict[str, str]]
 
 
 BATCH_GET_RECORD_MAX_ITEMS = 10
+
+
+def feature_store_record_to_dict(
+    record: FeatureStoreRecordType,
+    lowercase_names: bool = True,
+) -> Dict[str, str]:
+    """
+    Converts a feature group record to a dict
+    :param lowercase_names: If true, feature names will be returned as lowercase, otherwise they are returned unchanged.
+    :param record: List of dicts, each with a 'FeatureName' and 'ValueAsString'
+    :return: Dict keyed on feature name
+    """
+    return {
+        feature['FeatureName'].lower() if lowercase_names else feature['FeatureName']:
+        feature['ValueAsString']
+        for feature in record
+    }

--- a/app/data_providers/util/iteration.py
+++ b/app/data_providers/util/iteration.py
@@ -1,0 +1,15 @@
+from typing import Generator, TypeVar, Sequence
+
+
+T = TypeVar('T')
+
+
+# For Generator type-hint explanation, see https://docs.python.org/3/library/typing.html#typing.Generator
+def chunks(sequence: Sequence[T], n: int) -> Generator[Sequence[T], None, None]:
+    """
+    Yield successive n-sized chunks (or smaller) from the sequence.
+
+    Copied from https://github.com/Pocket/data-flows/blob/main/src/utils/iteration.py
+    """
+    for i in range(0, len(sequence), n):
+        yield sequence[i: i + n]

--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -5,6 +5,7 @@ import aioboto3
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.corpus.curated_corpus_api_client import CuratedCorpusAPIClient
+from app.data_providers.corpus_metrics_provider import CorpusMetricsProvider
 from app.data_providers.metrics_client import MetricsClient
 from app.data_providers.slate_provider import SlateProvider
 from app.data_providers.snowplow.config import SnowplowConfig, create_snowplow_tracker
@@ -91,11 +92,14 @@ class Query(ObjectType):
         recommendation_count = int(get_field_argument(
             info.field_asts, ['setupMomentSlate', 'recommendations'], 'count', default_value=CorpusSlate.DEFAULT_COUNT))
 
+        metrics_provider = CorpusMetricsProvider(aioboto3_session)
+
         return await SetupMomentDispatch(
             corpus_client=corpus_client,
             user_recommendation_preferences_provider=user_recommendation_preferences_provider,
             slate_tracker=slate_tracker,
             topic_provider=topic_provider,
+            metrics_provider=metrics_provider,
         ).get_ranked_corpus_slate(
             user=info.context['user'],
             recommendation_count=recommendation_count,

--- a/app/models/corpus_slate_config_model.py
+++ b/app/models/corpus_slate_config_model.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel
+
+
+class CorpusSlateConfigModel(BaseModel):
+    """
+    Unique identifier for this Corpus Slate config
+    """
+    id: str

--- a/app/models/corpus_slate_config_model.py
+++ b/app/models/corpus_slate_config_model.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-from typing import List
-
 from pydantic import BaseModel
 
 

--- a/app/models/metrics/corpus_metrics_model.py
+++ b/app/models/metrics/corpus_metrics_model.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from app.models.surface import Surface
+
+
+class CorpusMetricsSegmentModel(BaseModel):
+    """
+    Defines the dimensions along which metrics are segmented
+    """
+    surface: Surface
+    corpus_slate_config_id: str
+    corpus_item_id: str
+
+
+class CorpusMetricsModel(BaseModel):
+    """
+    Extends the above segment model with metrics.
+    """
+    segment: CorpusMetricsSegmentModel
+    updated_at: datetime = None
+    trailing_1_day_opens: int
+    trailing_1_day_impressions: int
+    trailing_7_day_opens: int
+    trailing_7_day_impressions: int
+    trailing_14_day_opens: int
+    trailing_14_day_impressions: int
+    trailing_28_day_opens: int
+    trailing_28_day_impressions: int

--- a/app/models/surface.py
+++ b/app/models/surface.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Surface(Enum):
+    SETUP_MOMENT = 'SETUP_MOMENT'
+    HOME = 'HOME'

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -7,6 +7,7 @@ import random
 from aws_xray_sdk.core import xray_recorder
 
 from app.models.corpus_item_model import CorpusItemModel
+from app.models.metrics.corpus_metrics_model import CorpusMetricsModel
 from app.models.metrics.metrics_model import MetricsModel
 from app.models.metrics.firefox_new_tab_metrics_model import FirefoxNewTabMetricsModel
 
@@ -101,7 +102,7 @@ def blocklist(recs: RecommendationListType, blocklist: Optional[List[str]] = Non
 
 def thompson_sampling(
         recs: RankableListType,
-        metrics: Dict[(int or str), Union['MetricsModel', 'FirefoxNewTabMetricsModel']],
+        metrics: Dict[(int or str), Union['MetricsModel', 'FirefoxNewTabMetricsModel', 'CorpusMetricsModel']],
         trailing_period: int = 28,
         default_alpha_prior=DEFAULT_ALPHA_PRIOR,
         default_beta_prior=DEFAULT_BETA_PRIOR) -> RankableListType:


### PR DESCRIPTION
# Goal
Determine the data schema we need to rank content on Unified Home and Setup Moment. Use Setup Moment as a test-case because it already exists today.

Changes:
- Add a new Feature Group "corpus-engagement"
- Add a data provider to fetch metrics from the Feature Group
- Rank Setup Moment using Thompson sampling

## Todos
- [x] Create `development-corpus-engagement-v1` Feature Group
- [ ] QA that Setup Moment is ranked approximately by CTR in Pocket-Dev

## Deployment
- [ ] Create `production-corpus-engagement-v1` Feature Group

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-128

## Implementation Decisions
- @lfishhead requested that we include multiple trailing day periods, and in recommendation API several periods are currently in use. My thinking is that it's probably easier now to add the same periods that are available today (1, 7, 14, 28 days) than to have add them later, even if we won't end up using all of these periods initially.

## Feature Group schema
[Athena](https://us-east-1.console.aws.amazon.com/athena/home?region=us-east-1#/query-editor/history/03627162-9fca-4b53-9c93-b28c7728d805) (Pocket-Dev feature group contains dummy data):
```sql
SELECT * FROM "sagemaker_featurestore"."development-corpus-engagement-v1-1660249623" limit 10;
```

### Schema
```python
[
    {
        # Combined key "surface/corpus_slate_config_id/corpus_item_id"
        "name": "KEY",
        "type": "string"
    },
    {
        # The date-time when these metrics were updated.
        "name": "UPDATED_AT",
        "type": "datetime"
    },
    {
        # Identifies the product surface where the recommendations are shown. Currently "SETUP_MOMENT" or "HOME".
        "name": "SURFACE",
        "type": "string"
    },
    {
        # Indentifies the slate configuration
        "name": "CORPUS_SLATE_CONFIG_ID",
        "type": "string"
    },
    {
        # Identifies the item being recommended
        "name": "CORPUS_ITEM_ID",
        "type": "string"
    },
    {
        "name": "TRAILING_1_DAY_OPENS",
        "type": "long"
    },
    {
        "name": "TRAILING_1_DAY_IMPRESSIONS",
        "type": "long"
    },
    {
        "name": "TRAILING_7_DAY_OPENS",
        "type": "long"
    },
    {
        "name": "TRAILING_7_DAY_IMPRESSIONS",
        "type": "long"
    },
    {
        "name": "TRAILING_14_DAY_OPENS",
        "type": "long"
    },
    {
        "name": "TRAILING_14_DAY_IMPRESSIONS",
        "type": "long"
    },
    {
        "name": "TRAILING_28_DAY_OPENS",
        "type": "long"
    },
    {
        "name": "TRAILING_28_DAY_IMPRESSIONS",
        "type": "long"
    },
]
```