### PR TITLE
fix(lambda): Fix breaking change in pipenv and lock pipenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             - run:
                 name: Package Lambda
                 # We bundle our code in a way that lambda can understand and execute
-                # - pipenv lock -r > requirements.txt - output a requirements.txt file from Pipfile
+                # - pipenv requirements > requirements.txt - output a requirements.txt file from Pipfile
                 # - pip install -r requirements.txt --no-deps -t package | installs the requirements into a "package" directory
                 # - change dir into the "package" dir and add all the packages to a zip file as /tmp
                 # - change dir into the "aws_lambda" dir and remove all files and folder we want to exclude from the build
@@ -189,9 +189,9 @@ jobs:
                 # - copy the zip file to /tmp/build.zip and store as a CI artifact for quick inspection of the build
                 command: |
                   apt-get update && apt-get install zip
-                  pip install pipenv
+                  pip install pipenv==2022.8.15
                   cd aws_lambda
-                  pipenv lock -r > requirements.txt
+                  pipenv requirements > requirements.txt
                   pip install -r requirements.txt --no-deps -t package
                   cd package
                   mkdir -p /tmp


### PR DESCRIPTION
# Goal
Fix Lambda [deployment error](https://app.circleci.com/jobs/github/Pocket/recommendation-api/16628?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link):
> Usage: pipenv lock [OPTIONS]
> Try 'pipenv lock -h' for help.
> 
> Error: No such option: -r

## Reference

Pipenv changelog:
* https://github.com/pypa/pipenv/blob/main/CHANGELOG.rst#removals-and-deprecations

CircleCI error:
* https://app.circleci.com/pipelines/github/Pocket/recommendation-api/3565/workflows/f0dfda56-90e7-4551-8f2a-c33a90893a11/jobs/16628

## Implementation Decisions
- Lock pipenv to the current version to avoid breaking changes going forward.