### PR TITLE
feat(Home): Add personalized Home slates

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from asyncio import gather
@@ -6,6 +7,7 @@ from typing import List
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
+from app.data_providers.slate_providers.personalized_for_you_slate_provider import PersonalizedForYouSlateProvider
 from app.data_providers.slate_providers.topic_slate_provider import TopicSlateProvider
 from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
@@ -13,6 +15,7 @@ from app.data_providers.util import flatten
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_lineup_model import CorpusSlateLineupModel
 from app.models.corpus_slate_model import CorpusSlateModel
+from app.models.topic import TopicModel
 from app.models.user_ids import UserIds
 from app.rankers.algorithms import rank_by_preferred_topics
 
@@ -82,27 +85,56 @@ class HomeDispatch:
             corpus_client: CorpusFeatureGroupClient,
             user_recommendation_preferences_provider: UserRecommendationPreferencesProvider,
             topic_provider: TopicProvider,
+            personalized_for_you_slate_provider: PersonalizedForYouSlateProvider,
             topic_slate_provider: TopicSlateProvider,
             collection_slate_provider: CollectionSlateProvider,
     ):
         self.topic_provider = topic_provider
         self.corpus_client = corpus_client
         self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
+        self.personalized_for_you_slate_provider = personalized_for_you_slate_provider
         self.topic_slate_provider = topic_slate_provider
         self.collection_slate_provider = collection_slate_provider
 
     async def get_slate_lineup(
             self, user: UserIds, slate_count: int, recommendation_count: int
     ) -> CorpusSlateLineupModel:
+        """
+        Returns the Home slate lineup:
+        1. 'For You' slate if preferred topics are available, otherwise this slate is simply not shown.
+        2. Collection slate
+        3. Topic slates according to preferred topics if available, otherwise default topics.
+
+        :param user:
+        :param slate_count:
+        :param recommendation_count:
+        :return:
+        """
+        slates = []
+
+        preferred_topics = await self._get_preferred_topics(user)
+        if preferred_topics:
+            slates += [self.personalized_for_you_slate_provider.get_slate(preferred_topics, recommendation_count)]
+
+        slates += [
+            self.collection_slate_provider.get_slate(),
+            self._get_topic_slates(preferred_topics=preferred_topics, recommendation_count=recommendation_count),
+        ]
+
         return CorpusSlateLineupModel(
             slates=flatten(list(
-                await gather(
-                    self.collection_slate_provider.get_slate(),
-                    self._get_topic_slates(recommendation_count=recommendation_count),
-                )
+                await gather(*slates)
             )),
         )
 
-    async def _get_topic_slates(self, recommendation_count: int) -> List[CorpusSlateModel]:
-        topics = await self.topic_provider.get_topics(self.DEFAULT_TOPICS)
+    async def _get_preferred_topics(self, user: UserIds) -> List[TopicModel]:
+        user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(str(user.user_id))
+        if user_recommendation_preferences and user_recommendation_preferences.preferred_topics:
+            return user_recommendation_preferences.preferred_topics
+        else:
+            return []
+
+    async def _get_topic_slates(self, preferred_topics: List[TopicModel], recommendation_count: int) -> List[CorpusSlateModel]:
+        preferred_topic_ids = [t.id for t in preferred_topics]
+        topics = await self.topic_provider.get_topics(preferred_topic_ids or self.DEFAULT_TOPICS)
         return await self.topic_slate_provider.get_slates(topics, recommendation_count=recommendation_count)

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import uuid
 from asyncio import gather

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -6,7 +6,7 @@ from typing import List
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
-from app.data_providers.slate_providers.personalized_for_you_slate_provider import PersonalizedForYouSlateProvider
+from app.data_providers.slate_providers.personalized_for_you_slate_provider import ForYouSlateProvider
 from app.data_providers.slate_providers.topic_slate_provider import TopicSlateProvider
 from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
@@ -82,16 +82,16 @@ class HomeDispatch:
     def __init__(
             self,
             corpus_client: CorpusFeatureGroupClient,
-            user_recommendation_preferences_provider: UserRecommendationPreferencesProvider,
+            preferences_provider: UserRecommendationPreferencesProvider,
             topic_provider: TopicProvider,
-            personalized_for_you_slate_provider: PersonalizedForYouSlateProvider,
+            for_you_slate_provider: ForYouSlateProvider,
             topic_slate_provider: TopicSlateProvider,
             collection_slate_provider: CollectionSlateProvider,
     ):
         self.topic_provider = topic_provider
         self.corpus_client = corpus_client
-        self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
-        self.personalized_for_you_slate_provider = personalized_for_you_slate_provider
+        self.preferences_provider = preferences_provider
+        self.for_you_slate_provider = for_you_slate_provider
         self.topic_slate_provider = topic_slate_provider
         self.collection_slate_provider = collection_slate_provider
 
@@ -113,7 +113,7 @@ class HomeDispatch:
 
         preferred_topics = await self._get_preferred_topics(user)
         if preferred_topics:
-            slates += [self.personalized_for_you_slate_provider.get_slate(preferred_topics, recommendation_count)]
+            slates += [self.for_you_slate_provider.get_slate(preferred_topics, recommendation_count)]
 
         slates += [
             self.collection_slate_provider.get_slate(),
@@ -127,9 +127,9 @@ class HomeDispatch:
         )
 
     async def _get_preferred_topics(self, user: UserIds) -> List[TopicModel]:
-        user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(str(user.user_id))
-        if user_recommendation_preferences and user_recommendation_preferences.preferred_topics:
-            return user_recommendation_preferences.preferred_topics
+        preferences = await self.preferences_provider.fetch(str(user.user_id))
+        if preferences and preferences.preferred_topics:
+            return preferences.preferred_topics
         else:
             return []
 

--- a/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
@@ -9,7 +9,7 @@ from app.models.topic import TopicModel
 from app.rankers.algorithms import rank_by_preferred_topics
 
 
-class PersonalizedForYouSlateProvider:
+class ForYouSlateProvider:
 
     _EN_RECOMMENDED_CANDIDATE_SET_ID = '2066c835-a940-45ec-b1f7-267457d9e0a2'
 

--- a/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
@@ -1,0 +1,39 @@
+from typing import List, Dict
+
+from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
+from app.models.corpus_recommendation_model import CorpusRecommendationModel
+from app.models.corpus_slate_model import CorpusSlateModel
+from app.models.link import LinkModel
+from app.models.recommendation_reason_model import RecommendationReasonModel
+from app.models.recommendation_reason_type import RecommendationReasonType
+from app.models.topic import TopicModel
+from app.rankers.algorithms import rank_by_preferred_topics
+
+
+class PersonalizedForYouSlateProvider:
+
+    _EN_RECOMMENDED_CANDIDATE_SET_ID = '2066c835-a940-45ec-b1f7-267457d9e0a2'
+
+    def __init__(self, corpus_feature_group_client: CorpusFeatureGroupClient):
+        self.corpus_feature_group_client = corpus_feature_group_client
+
+    async def get_slate(self, preferred_topics: List[TopicModel], recommendation_count: int) -> CorpusSlateModel:
+        items = await self.corpus_feature_group_client.fetch(self._EN_RECOMMENDED_CANDIDATE_SET_ID)
+        items = rank_by_preferred_topics(items, preferred_topics, recommendation_count)
+
+        preferred_topic_by_id: Dict[str, TopicModel] = {t.corpus_topic_id: t for t in preferred_topics}
+
+        return CorpusSlateModel(
+            headline='Recommended For You',
+            subheadline='Curated for your interests',
+            recommendation_reason_type=RecommendationReasonType.PREFERRED_TOPICS,
+            recommendations=[
+                CorpusRecommendationModel(
+                    corpus_item=item,
+                    reason=RecommendationReasonModel(
+                        name=preferred_topic_by_id[item.topic].name,
+                        type=RecommendationReasonType.PREFERRED_TOPICS,
+                    ) if item.topic in preferred_topic_by_id else None,  # Only put reason on items with preferred topic
+                ) for item in items
+            ],
+        )

--- a/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/personalized_for_you_slate_provider.py
@@ -3,7 +3,6 @@ from typing import List, Dict
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_model import CorpusSlateModel
-from app.models.link import LinkModel
 from app.models.recommendation_reason_model import RecommendationReasonModel
 from app.models.recommendation_reason_type import RecommendationReasonType
 from app.models.topic import TopicModel

--- a/app/data_providers/slate_providers/topic_slate_provider.py
+++ b/app/data_providers/slate_providers/topic_slate_provider.py
@@ -1,11 +1,8 @@
 import random
-import uuid
 from asyncio import gather
-from datetime import datetime, timezone
 from typing import List
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
-from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_model import CorpusSlateModel
 from app.models.link import LinkModel

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -6,7 +6,7 @@ from strawberry.types import Info
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.dispatch import HomeDispatch
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
-from app.data_providers.slate_providers.personalized_for_you_slate_provider import PersonalizedForYouSlateProvider
+from app.data_providers.slate_providers.personalized_for_you_slate_provider import ForYouSlateProvider
 from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.slate_providers.topic_slate_provider import TopicSlateProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
@@ -41,9 +41,9 @@ async def resolve_home_slate_lineup(root, info: Info) -> Optional[CorpusSlateLin
 
     slate_lineup_model = await HomeDispatch(
         corpus_client=corpus_client,
-        user_recommendation_preferences_provider=user_recommendation_preferences_provider,
+        preferences_provider=user_recommendation_preferences_provider,
         topic_provider=topic_provider,
-        personalized_for_you_slate_provider=PersonalizedForYouSlateProvider(corpus_client),
+        for_you_slate_provider=ForYouSlateProvider(corpus_client),
         topic_slate_provider=TopicSlateProvider(corpus_client),
         collection_slate_provider=CollectionSlateProvider(corpus_client),
     ).get_slate_lineup(

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -6,6 +6,7 @@ from strawberry.types import Info
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.dispatch import HomeDispatch
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
+from app.data_providers.slate_providers.personalized_for_you_slate_provider import PersonalizedForYouSlateProvider
 from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.slate_providers.topic_slate_provider import TopicSlateProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
@@ -42,6 +43,7 @@ async def resolve_home_slate_lineup(root, info: Info) -> Optional[CorpusSlateLin
         corpus_client=corpus_client,
         user_recommendation_preferences_provider=user_recommendation_preferences_provider,
         topic_provider=topic_provider,
+        personalized_for_you_slate_provider=PersonalizedForYouSlateProvider(corpus_client),
         topic_slate_provider=TopicSlateProvider(corpus_client),
         collection_slate_provider=CollectionSlateProvider(corpus_client),
     ).get_slate_lineup(

--- a/app/models/corpus_slate_model.py
+++ b/app/models/corpus_slate_model.py
@@ -31,5 +31,6 @@ class CorpusSlateModel(BaseModel):
         default=None,
         description='A smaller, secondary headline that can be displayed to provide additional context on the slate.')
     more_link: Optional[LinkModel] = Field(
+        default=None,
         description='Link to a page where the user can explore more recommendations similar to this slate, or null if '
                     'no link is provided.')

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -109,7 +109,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
             # Assert that the expected number of slates is being returned.
             assert len(slates) == 4
             # First slate is personalized
-            assert slates[0]['headline'] == 'Recommended For You'
+            assert slates[0]['headline'] == 'For You'
             # Second slate has a link to the collections page
             assert slates[1]['moreLink']['url'] == 'https://getpocket.com/collections'
             # Last slates match preferred topics

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -3,6 +3,7 @@ import random
 import uuid
 from typing import Sequence
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
@@ -44,6 +45,32 @@ def _get_topics_fixture(topics_ids: Sequence[str]) -> List[TopicModel]:
     return [topics_by_id[id] for id in topics_ids]
 
 
+HOME_SLATE_LINEUP_QUERY = '''
+    query {
+      homeSlateLineup {
+        id
+        slates(count: 4) {
+          headline
+          moreLink {
+            url
+            text
+          }
+          recommendationReasonType
+          recommendations(count: 5) {
+            corpusItem {
+              id
+            }
+            reason {
+              name
+              type
+            }
+          }
+        }
+      }
+    }
+'''
+
+
 class TestHomeSlateLineup(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
@@ -51,6 +78,10 @@ class TestHomeSlateLineup(TestDynamoDBBase):
             user_id=1,
             hashed_user_id='1-hashed',
         )
+        self.headers = {
+            'userId': str(self.user_ids.user_id),
+            'encodedId': self.user_ids.hashed_user_id,
+        }
 
         populate_topics(self.metadata_table)
 
@@ -59,7 +90,11 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
-    def test_home_slate_lineup(self, mock_fetch_user_recommendation_preferences, mock_get_ranked_corpus_items):
+    def test_personalized_home_slate_lineup(
+            self,
+            mock_fetch_user_recommendation_preferences,
+            mock_get_ranked_corpus_items
+    ):
         corpus_items_fixture = _corpus_items_fixture(n=100)
         mock_get_ranked_corpus_items.return_value = corpus_items_fixture
 
@@ -68,47 +103,47 @@ class TestHomeSlateLineup(TestDynamoDBBase):
         mock_fetch_user_recommendation_preferences.return_value = preferences_fixture
 
         with TestClient(app) as client:
-            data = client.post(
-                '/',
-                json={
-                    'query': '''
-                        query {
-                          homeSlateLineup {
-                            id
-                            slates(count: 4) {
-                              headline
-                              moreLink {
-                                url
-                                text
-                              }
-                              recommendationReasonType
-                              recommendations(count: 5) {
-                                corpusItem {
-                                  id
-                                }
-                                reason {
-                                  name
-                                  type
-                                }
-                              }
-                            }
-                          }
-                        }
-                    ''',
-                },
-                headers={
-                    'userId': str(self.user_ids.user_id),
-                    'encodedId': self.user_ids.hashed_user_id,
-                }
-            ).json()
+            data = client.post('/', json={'query': HOME_SLATE_LINEUP_QUERY}, headers=self.headers).json()
 
             assert not data.get('errors')
-            slate_lineup = data['data']['homeSlateLineup']
-            slates = slate_lineup['slates']
+            slates = data['data']['homeSlateLineup']['slates']
 
             # Assert that the expected number of slates is being returned.
             assert len(slates) == 4
+            # First slate is personalized
+            assert slates[0]['headline'] == 'Recommended For You'
+            # Second slate has a link to the collections page
+            assert slates[1]['moreLink']['url'] == 'https://getpocket.com/collections'
+            # Last slates match preferred topics
+            assert slates[2]['moreLink']['url'] == f'https://getpocket.com/explore/{preferred_topics[0].slug}'
+            assert slates[3]['moreLink']['url'] == f'https://getpocket.com/explore/{preferred_topics[1].slug}'
 
+            recommendation_counts = [len(slate['recommendations']) for slate in slates]
+            assert recommendation_counts == len(slates)*[5]  # Each slates has 5 recs each
+
+            all_snowplow_events = self.snowplow_micro.get_event_counts()
+            # No Snowplow events are expected to be emitted at this point.
+            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}, self.snowplow_micro.get_last_error()
+
+    @patch.object(CorpusFeatureGroupClient, 'fetch')
+    @patch.object(UserRecommendationPreferencesProvider, 'fetch')
+    def test_unpersonalized_home_slate_lineup(
+            self,
+            mock_fetch_user_recommendation_preferences,
+            mock_get_ranked_corpus_items
+    ):
+        corpus_items_fixture = _corpus_items_fixture(n=100)
+        mock_get_ranked_corpus_items.return_value = corpus_items_fixture
+        mock_fetch_user_recommendation_preferences.return_value = None  # User has does not have a preferences record
+
+        with TestClient(app) as client:
+            data = client.post('/', json={'query': HOME_SLATE_LINEUP_QUERY}, headers=self.headers).json()
+
+            assert not data.get('errors')
+            slates = data['data']['homeSlateLineup']['slates']
+
+            # Assert that the expected number of slates is being returned.
+            assert len(slates) == 4
             # First slate has a link to the collections page
             assert slates[0]['moreLink']['url'] == 'https://getpocket.com/collections'
             # Last slates have topic explore links

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -3,7 +3,6 @@ import random
 import uuid
 from typing import Sequence
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
@@ -11,7 +10,6 @@ from app.data_providers.snowplow.config import SnowplowConfig
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
 from app.main import app
 from app.models.corpus_item_model import CorpusItemModel
-from app.models.topic import TopicModel
 from app.models.user_ids import UserIds
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 from tests.assets.topics import *


### PR DESCRIPTION
# Goal
When a user has set preferred topics, they should see personalized topic slates.

# Out of scope
* **Performance optimizations:** There is a [separate Jira ticket](https://getpocket.atlassian.net/browse/HS-192) to perform load testing and get performance in line with the SLA.
* **Requirements possibly not finalized:** There are some outstanding questions in the [Content Requirements doc](https://docs.google.com/document/d/15gBxnXlsKTgGyjZe72VUc43aK9ZoAArP9NaJDNLIaps/edit#heading=h.mljabq907ibf). We might have to come back and add some rankers if requirements are added, but I don't want to get blocked by that.
* **Impression capping:** Captured in [HS-203](https://getpocket.atlassian.net/browse/HS-203).

## Deployment
- [x] Pre-generate the new 'For You' candidate set `'2066c835-a940-45ec-b1f7-267457d9e0a2'` in development and production Feature Store. https://github.com/Pocket/data-flows/pull/129

## Reference

Requirements

- [Figma Design](https://www.figma.com/file/jawk2lhpNJZZWSJqE3DuNn/Unified-Home-Experiments)
- [Content Requirements](https://docs.google.com/document/d/15gBxnXlsKTgGyjZe72VUc43aK9ZoAArP9NaJDNLIaps/edit#heading=h.mljabq907ibf)

API spec

- [API proposal Confluence page](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2779938817/Unified+Home)
- https://github.com/Pocket/spec/pull/161

Tickets:
* https://getpocket.atlassian.net/browse/HS-207
* https://getpocket.atlassian.net/browse/HS-216

## Implementation Decisions
