### PR TITLE
Home minor graphql changes

### DIFF
--- a/app/graphql/graphql_router.py
+++ b/app/graphql/graphql_router.py
@@ -28,7 +28,8 @@ class Query:
     setup_moment_slate: CorpusSlate = strawberry.field(
         resolver=resolve_setup_moment_slate,
         description='Get stories during Setup Moment onboarding that are personalized with user preferences provided '
-                    'during onboarding.'
+                    'during onboarding.',
+        deprecation_reason='Setup Moment has been integrated into Home.',
     )
 
     recommendation_preference_topics: List[Topic] = strawberry.field(

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -18,7 +18,7 @@ from app.graphql.resolvers.corpus_slate_recommendations_resolver import DEFAULT_
 from app.graphql.util import get_field_argument, get_user_ids
 
 
-async def resolve_home_slate_lineup(root, info: Info) -> Optional[CorpusSlateLineup]:
+async def resolve_home_slate_lineup(root, info: Info) -> CorpusSlateLineup:
     aioboto3_session = aioboto3.Session()
     corpus_client = CorpusFeatureGroupClient(aioboto3_session=aioboto3_session)
     user = get_user_ids(info)

--- a/app/graphql/resolvers/corpus_slate_lineup_slates_resolver.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_slates_resolver.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from app.graphql.corpus_slate_lineup import CorpusSlateLineup
 
 
-DEFAULT_SLATE_COUNT = 10  # The maximum number of recommendations that is returned by default in a CorpusSlate.
+DEFAULT_SLATE_COUNT = 15  # The maximum number of recommendations that is returned by default in a CorpusSlate.
 
 
 def corpus_slate_lineup_slates_resolver(

--- a/app/graphql/resolvers/legacy/slate_lineup_resolver.py
+++ b/app/graphql/resolvers/legacy/slate_lineup_resolver.py
@@ -15,7 +15,7 @@ async def resolve_get_slate_lineup(
         slate_count: Annotated[Optional[int], argument(
             description='Maximum number of slates to return in {SlateLineup.slates}, defaults to 8')] = 8,
         recommendation_count: Annotated[Optional[int], argument(
-            description='Maximum number of recommendations to return in {Slate.recommendations}, defaults to 10')] = 10,
+            description='Maximum number of recommendations to return in {Slate.recommendations}, defaults to 15')] = 15,
 ) -> Optional[SlateLineup]:
     slate_lineup_model = await SlateLineupModel.get_slate_lineup_with_fallback(
         slate_lineup_id=slate_lineup_id,

--- a/app/graphql/resolvers/legacy/slate_lineup_resolver.py
+++ b/app/graphql/resolvers/legacy/slate_lineup_resolver.py
@@ -15,7 +15,7 @@ async def resolve_get_slate_lineup(
         slate_count: Annotated[Optional[int], argument(
             description='Maximum number of slates to return in {SlateLineup.slates}, defaults to 8')] = 8,
         recommendation_count: Annotated[Optional[int], argument(
-            description='Maximum number of recommendations to return in {Slate.recommendations}, defaults to 15')] = 15,
+            description='Maximum number of recommendations to return in {Slate.recommendations}, defaults to 10')] = 10,
 ) -> Optional[SlateLineup]:
     slate_lineup_model = await SlateLineupModel.get_slate_lineup_with_fallback(
         slate_lineup_id=slate_lineup_id,

--- a/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
+++ b/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
@@ -18,7 +18,7 @@ from app.models.user_recommendation_preferences import UserRecommendationPrefere
 
 
 async def update_user_recommendation_preferences(
-        root, info: Info, input: UpdateUserRecommendationPreferencesInput) -> Optional[UserRecommendationPreferences]:
+        root, info: Info, input: UpdateUserRecommendationPreferencesInput) -> UserRecommendationPreferences:
     aioboto3_session = aioboto3.Session()
 
     topic_provider = TopicProvider(aioboto3_session=aioboto3_session)

--- a/app/models/corpus_recommendation_model.py
+++ b/app/models/corpus_recommendation_model.py
@@ -15,7 +15,7 @@ class CorpusRecommendationModel(BaseModel):
                     'This field can be joined with recommendation decisions to aggregate more meta data about the '
                     'decision.')
 
-    corpus_item: Optional[CorpusItemModel] = Field(description='Content meta data.')
+    corpus_item: CorpusItemModel = Field(description='Content meta data.')
 
     reason: Optional[RecommendationReasonModel] = Field(
         default=None,


### PR DESCRIPTION
# Goal
Minor cleanup of the GraphQL schema:
- Increase default Home slate count from 10 to 15, to meet the product requirement that [all topic slates will be shown](https://docs.google.com/document/d/15gBxnXlsKTgGyjZe72VUc43aK9ZoAArP9NaJDNLIaps/edit) that the user selects.
- Make some types required that were accidentally marked as optional before.
- Deprecate `setupMomentSlate`.

# References

- [Proposal on Confluence](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2805923841/Recommendation+API+-+Minor+cleanup)
   - We agreed to create a proposal even for minor changes like this.