### PR TITLE
fix(Home): Restore missing 'Update your topics' link (HS-300)

### DIFF
--- a/app/data_providers/slate_providers/for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/for_you_slate_provider.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from app.data_providers.slate_providers.slate_provider import SlateProvider
 from app.models.corpus_item_model import CorpusItemModel
@@ -22,6 +22,13 @@ class ForYouSlateProvider(SlateProvider):
     @property
     def subheadline(self) -> str:
         return 'Recommended for your interests'
+
+    @property
+    def recommendation_reason_type(self) -> Optional[RecommendationReasonType]:
+        """
+        :return: Recommendations in this slate are optimized to match the user's preferred topics.
+        """
+        return RecommendationReasonType.PREFERRED_TOPICS
 
     async def rank_corpus_items(
             self,

--- a/app/data_providers/slate_providers/slate_provider.py
+++ b/app/data_providers/slate_providers/slate_provider.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from uuid import uuid5, UUID
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
+from app.graphql.recommendation_reason_type import RecommendationReasonType
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_model import CorpusSlateModel
@@ -58,6 +59,13 @@ class SlateProvider(ABC):
         """
         return str(uuid5(UUID(self.candidate_set_id), self.provider_name))
 
+    @property
+    def recommendation_reason_type(self) -> Optional[RecommendationReasonType]:
+        """
+        :return: (optional) Reason why recommendations in this slate are recommended.
+        """
+        return None
+
     async def get_candidate_corpus_items(self) -> List[CorpusItemModel]:
         """
         :return: The CorpusItems from the candidate set, without any rankers or filters applied.
@@ -96,4 +104,5 @@ class SlateProvider(ABC):
             subheadline=self.subheadline,
             more_link=self.more_link,
             recommendations=recommendations,
+            recommendation_reason_type=self.recommendation_reason_type,
         )

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -110,6 +110,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
             assert len(slates) == 4
             # First slate is personalized
             assert slates[0]['headline'] == 'For You'
+            assert slates[0]['recommendationReasonType'] == 'PREFERRED_TOPICS'
             # Second slate has a link to the collections page
             assert slates[1]['moreLink']['url'] == 'https://getpocket.com/collections'
             # Last slates match preferred topics
@@ -141,8 +142,9 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             # Assert that the expected number of slates is being returned.
             assert len(slates) == 5
-            # Fisrt slate has an unpersonalized recommendations
+            # First slate has an unpersonalized recommendations
             assert slates[0]['headline'] == 'Recommended Reads'
+            assert slates[0]['recommendationReasonType'] is None
             # Second slate has a link to the collections page
             assert slates[1]['moreLink']['url'] == 'https://getpocket.com/collections'
             # Last slates have topic explore links


### PR DESCRIPTION
# Goal
Restore 'Update your topics' link that was accidentally removed as part of the refactor in https://github.com/Pocket/recommendation-api/pull/958. The cause is that the 'For You' slate stopped returning `recommendationReasonType`.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-300

## Implementation Decisions
- I don't really like the pattern of duplicating `CorpusSlate` fields as properties. Maybe a better pattern is to pass the CorpusSlate object to a method `set_slate_specific_fields` that can be overridden to set any optional attribute such as `more_link`, `subheadline`, and `recommendation_reason_type`.