### PR TITLE
fix(Home): 414 error occurs on Snowplow slate lineup event (HS-301)

### DIFF
--- a/app/data_providers/snowplow/config.py
+++ b/app/data_providers/snowplow/config.py
@@ -1,5 +1,5 @@
 from aio_snowplow_tracker import Tracker, Emitter
-from aio_snowplow_tracker.typing import HttpProtocol
+from aio_snowplow_tracker.typing import HttpProtocol, Method
 
 from app.config import ENV, ENV_PROD, ENV_DEV, ENV_LOCAL
 
@@ -17,6 +17,8 @@ class SnowplowConfig:
     )
 
     PROTOCOL: HttpProtocol = 'http' if ENV == ENV_LOCAL else 'https'
+    METHOD: Method = 'post'
+    BUFFER_SIZE: int = 1  # Number of events to buffer before flushing to Snowplow. 1 = No buffer.
 
     CORPUS_SLATE_SCHEMA = 'iglu:com.pocket/corpus_slate/jsonschema/3-0-0'
     CORPUS_SLATE_LINEUP_SCHEMA = 'iglu:com.pocket/corpus_slate_lineup/jsonschema/1-0-11'
@@ -32,5 +34,7 @@ def create_snowplow_tracker() -> Tracker:
     emitter = Emitter(
         SnowplowConfig.ENDPOINT_URL,
         protocol=SnowplowConfig.PROTOCOL,
+        method=SnowplowConfig.METHOD,
+        buffer_size=SnowplowConfig.BUFFER_SIZE,
     )
     return Tracker(emitter, app_id=SnowplowConfig.APP_ID)


### PR DESCRIPTION
# Goal
Fix an [error](https://sentry.io/organizations/pocket/issues/3436829509/?environment=production&project=5503693&query=is%3Aunresolved#request) where Snowplow responds with a 414 Uri Too Long status.

This probably happens because by default, it encodes the payload as URL parameters in a Get request. Switching to Post should fix this.

## Testing
Unfortunately, this error did not occur in Snowplow Micro or Snowplow Mini, which both successfully validated the event. It seems to only occur in production, for some reason.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-301

Sentry:
* https://sentry.io/organizations/pocket/issues/3436829509/?environment=production&project=5503693&query=is%3Aunresolved#request

## Implementation Decisions
Set `buffer_size` to 1 to ensure all events are sent, without having to flush the buffer when the application is draining requests on shutdown. As a future performance optimization, it's probably better to make the Snowplow request in the background than to use buffering.