### PR TITLE
fix(Home): Correct copy on Pocket Hits and Life Hacks [HS-351]

### DIFF
--- a/app/data_providers/slate_providers/life_hacks_slate_provider.py
+++ b/app/data_providers/slate_providers/life_hacks_slate_provider.py
@@ -13,4 +13,4 @@ class LifeHacksSlateProvider(SlateProvider):
 
     @property
     def subheadline(self) -> str:
-        return 'Curated by Pocket'
+        return 'Tips for better living'

--- a/app/data_providers/slate_providers/pocket_hits_slate_provider.py
+++ b/app/data_providers/slate_providers/pocket_hits_slate_provider.py
@@ -13,7 +13,12 @@ class PocketHitsSlateProvider(SlateProvider):
 
     @property
     def headline(self) -> str:
-        return f'{datetime.now().strftime("%A")}’s Pocket Hits'
+        return 'Today’s Pocket Hits'
+
+    @property
+    def subheadline(self) -> str:
+        dt = datetime.now()
+        return f'{dt:%A}, {dt:%B} {dt.day}'
 
     @property
     def recommendation_reason_type(self) -> Optional[RecommendationReasonType]:

--- a/tests/unit/data_providers/test_pocket_hits_slate_provider.py
+++ b/tests/unit/data_providers/test_pocket_hits_slate_provider.py
@@ -31,5 +31,5 @@ class TestPocketHitsSlateProvider:
     async def test_headline(self):
         slate = await self.slate_provider.get_slate()
 
-        assert slate.headline == 'Monday’s Pocket Hits'
-        assert slate.subheadline is None
+        assert slate.headline == 'Today’s Pocket Hits'
+        assert slate.subheadline == 'Monday, October 24'


### PR DESCRIPTION
# Goal
Update Home content experiment copy. [Carolyn says](https://pocket.slack.com/archives/C03JSA26QGP/p1666734649834359?thread_ts=1666728842.406359&cid=C03JSA26QGP) the accurate copy is:

Life Hacks
Tips for better living

Today's Pocket Hits
Weekday, Month date

## Reference

* [Jira ticket](https://getpocket.atlassian.net/browse/HS-351)
* [Design](https://www.figma.com/file/jawk2lhpNJZZWSJqE3DuNn/Unified-Home-Experiments)
* [Slack thread](https://pocket.slack.com/archives/C03JSA26QGP/p1666734649834359?thread_ts=1666728842.406359&cid=C03JSA26QGP)