### PR TITLE
feat(Home): Send locale to Unleash [HS-353]

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -22,7 +22,7 @@ from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_lineup_model import CorpusSlateLineupModel, RecommendationSurfaceId
 from app.models.corpus_slate_model import CorpusSlateModel
 from app.models.topic import TopicModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from app.rankers.algorithms import rank_by_preferred_topics, spread_topics
 
 
@@ -54,7 +54,7 @@ class SetupMomentDispatch:
         self.corpus_client = corpus_client
         self.user_recommendation_preferences_provider = user_recommendation_preferences_provider
 
-    async def get_ranked_corpus_slate(self, user: UserIds, recommendation_count: int) -> CorpusSlateModel:
+    async def get_ranked_corpus_slate(self, user: RequestUser, recommendation_count: int) -> CorpusSlateModel:
         items = await self.corpus_client.get_corpus_items(self.CORPUS_CANDIDATE_SET_IDS)
 
         user_recommendation_preferences = await self.user_recommendation_preferences_provider.fetch(str(user.user_id))
@@ -118,7 +118,7 @@ class HomeDispatch:
 
     @xray_recorder.capture_async('HomeDispatch.get_slate_lineup')
     async def get_slate_lineup(
-            self, user: UserIds, slate_count: int, recommendation_count: int
+            self, user: RequestUser, slate_count: int, recommendation_count: int
     ) -> CorpusSlateLineupModel:
         """
         Returns the Home slate lineup:
@@ -187,7 +187,7 @@ class HomeDispatch:
         return slates
 
     @xray_recorder.capture_async('HomeDispatch._get_preferred_topics')
-    async def _get_preferred_topics(self, user: UserIds) -> List[TopicModel]:
+    async def _get_preferred_topics(self, user: RequestUser) -> List[TopicModel]:
         preferences = await self.preferences_provider.fetch(str(user.user_id))
         if preferences and preferences.preferred_topics:
             return preferences.preferred_topics

--- a/app/data_providers/snowplow/snowplow_corpus_slate_lineup_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_slate_lineup_tracker.py
@@ -13,7 +13,7 @@ from app.data_providers.snowplow.subject import get_subject
 from app.models.api_client import ApiClient
 from app.models.corpus_slate_lineup_model import CorpusSlateLineupModel
 from app.models.unleash_assignment import UnleashAssignmentModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
 class SnowplowCorpusSlateLineupTracker:
@@ -27,7 +27,7 @@ class SnowplowCorpusSlateLineupTracker:
         self.snowplow_config = snowplow_config
 
     @xray_recorder.capture_async('SnowplowCorpusSlateLineupTracker.track')
-    async def track(self, corpus_slate_lineup: CorpusSlateLineupModel, user: UserIds, api_client: ApiClient):
+    async def track(self, corpus_slate_lineup: CorpusSlateLineupModel, user: RequestUser, api_client: ApiClient):
         """
         Track the recommendation of a CorpusSlateLineup in Snowplow.
         :param corpus_slate_lineup: The slate lineup that was recommended.
@@ -41,7 +41,7 @@ class SnowplowCorpusSlateLineupTracker:
 
         await asyncio.gather(*track_calls)
 
-    async def track_recommendation_metadata(self, corpus_slate_lineup: CorpusSlateLineupModel, user: UserIds):
+    async def track_recommendation_metadata(self, corpus_slate_lineup: CorpusSlateLineupModel, user: RequestUser):
         """
         Track the recommendation of a CorpusSlateLineup in Snowplow.
         :param corpus_slate_lineup: The slate lineup that was recommended.
@@ -67,7 +67,7 @@ class SnowplowCorpusSlateLineupTracker:
             context=context,
         )
 
-    async def track_variant_enroll(self, assignment: UnleashAssignmentModel, user: UserIds, api_client: ApiClient):
+    async def track_variant_enroll(self, assignment: UnleashAssignmentModel, user: RequestUser, api_client: ApiClient):
         """
         Track that the user was enrolled in an experiment.
         :param assignment: The experiment that the user was enrolled in.

--- a/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_slate_tracker.py
@@ -9,7 +9,7 @@ from app.data_providers.snowplow.entities import (
 )
 from app.data_providers.snowplow.subject import get_subject
 from app.models.corpus_slate_model import CorpusSlateModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
 class SnowplowCorpusSlateTracker:
@@ -23,7 +23,7 @@ class SnowplowCorpusSlateTracker:
         self.snowplow_config = snowplow_config
 
     @xray_recorder.capture_async('data_providers.SnowplowCorpusSlateTracker.track')
-    async def track(self, corpus_slate: CorpusSlateModel, user: UserIds):
+    async def track(self, corpus_slate: CorpusSlateModel, user: RequestUser):
         """
         Track the recommendation of a CorpusSlate in Snowplow.
         :param corpus_slate: The slate that was recommended.

--- a/app/data_providers/snowplow/subject.py
+++ b/app/data_providers/snowplow/subject.py
@@ -1,11 +1,11 @@
 from aio_snowplow_tracker import Subject
 
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
-def get_subject(user_ids: UserIds) -> Subject:
+def get_subject(user: RequestUser) -> Subject:
     """
-    :param user_ids:
+    :param user:
     :return: Snowplow Subject
     """
-    return Subject().set_user_id(str(user_ids.user_id))
+    return Subject().set_user_id(str(user.user_id))

--- a/app/data_providers/unleash_provider.py
+++ b/app/data_providers/unleash_provider.py
@@ -5,7 +5,7 @@ from aws_xray_sdk.core import xray_recorder
 from app.data_providers.PocketGraphClientSession import PocketGraphClientSession
 from app.config import ENV, ENV_PROD
 from app.models.unleash_assignment import UnleashAssignmentModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
 class UnleashConfig:
@@ -34,7 +34,7 @@ class UnleashProvider:
         self.pocket_graph_client_session = pocket_graph_client_session
         self.unleash_config = unleash_config
 
-    async def get_assignment(self, name: str, user: UserIds) -> Optional[UnleashAssignmentModel]:
+    async def get_assignment(self, name: str, user: RequestUser) -> Optional[UnleashAssignmentModel]:
         """
         :param name: name of the assignment
         :param user:
@@ -43,7 +43,7 @@ class UnleashProvider:
         assignments = await self.get_assignments([name], user=user)
         return assignments[0] if assignments else None
 
-    async def get_assignments(self, names: List[str], user: UserIds) -> List[UnleashAssignmentModel]:
+    async def get_assignments(self, names: List[str], user: RequestUser) -> List[UnleashAssignmentModel]:
         """
         Returns Unleash assignments with certain assignment names that the user is assigned to.
         :param names:
@@ -58,7 +58,7 @@ class UnleashProvider:
         return [assignment for assignment in all_assignments if assignment.name in names and assignment.assigned]
 
     @xray_recorder.capture_async('data_providers.UnleashProvider._get_all_assignments')
-    async def _get_all_assignments(self, user: UserIds) -> List[UnleashAssignmentModel]:
+    async def _get_all_assignments(self, user: RequestUser) -> List[UnleashAssignmentModel]:
         """
         Get all Unleash assignments for the given user/session.
         :param user:

--- a/app/data_providers/unleash_provider.py
+++ b/app/data_providers/unleash_provider.py
@@ -86,6 +86,9 @@ class UnleashProvider:
                     'environment': self.unleash_config.ENVIRONMENT,
                     'userId': user.hashed_user_id,
                     'sessionId': user.hashed_guid,
+                    'properties': {
+                        'locale': user.locale,
+                    }
                 }
             }
         }

--- a/app/data_providers/util.py
+++ b/app/data_providers/util.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 
 
 def flatten(items: List) -> List:
@@ -8,3 +8,7 @@ def flatten(items: List) -> List:
     :return: List of all non-list elements in sequence.
     """
     return sum(map(flatten, items), []) if isinstance(items, list) else [items]
+
+
+def get_dict_without_none(d: Dict) -> Dict:
+    return {k: v for k, v in d.items() if v is not None}

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -16,7 +16,7 @@ from app.data_providers.unleash_provider import UnleashProvider, UnleashConfig
 from app.graphql.corpus_slate_lineup import CorpusSlateLineup
 from app.graphql.resolvers.corpus_slate_lineup_slates_resolver import DEFAULT_SLATE_COUNT
 from app.graphql.resolvers.corpus_slate_recommendations_resolver import DEFAULT_RECOMMENDATION_COUNT
-from app.graphql.util import get_field_argument, get_user_ids, get_pocket_client
+from app.graphql.util import get_field_argument, get_request_user, get_pocket_client
 from app.singletons import (
     corpus_client,
     topic_provider,
@@ -26,7 +26,7 @@ from app.singletons import (
 
 
 async def resolve_home_slate_lineup(root, info: Info) -> CorpusSlateLineup:
-    user = get_user_ids(info)
+    user = get_request_user(info)
     api_client = get_pocket_client(info)
 
     slate_count = int(get_field_argument(

--- a/app/graphql/resolvers/corpus_slate_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_resolvers.py
@@ -11,7 +11,7 @@ from app.data_providers.topic_provider import TopicProvider
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProvider
 from app.graphql.corpus_slate import CorpusSlate
 from app.graphql.resolvers.corpus_slate_recommendations_resolver import DEFAULT_RECOMMENDATION_COUNT
-from app.graphql.util import get_field_argument, get_user_ids
+from app.graphql.util import get_field_argument, get_request_user
 
 
 async def resolve_setup_moment_slate(root, info: Info) -> Optional[CorpusSlate]:
@@ -22,7 +22,7 @@ async def resolve_setup_moment_slate(root, info: Info) -> Optional[CorpusSlate]:
         aioboto3_session=aioboto3_session,
         topic_provider=topic_provider
     )
-    user = get_user_ids(info)
+    user = get_request_user(info)
 
     recommendation_count = int(get_field_argument(
         fields=info.selected_fields,

--- a/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
+++ b/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
@@ -12,7 +12,7 @@ from app.data_providers.user_recommendation_preferences_provider import (
 )
 from app.graphql.update_user_recommendation_preferences_input import UpdateUserRecommendationPreferencesInput
 from app.graphql.user_recommendation_preferences import UserRecommendationPreferences
-from app.graphql.util import get_user_ids
+from app.graphql.util import get_request_user
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel, \
     UserRecommendationPreferencesModelV2
 
@@ -34,16 +34,16 @@ async def update_user_recommendation_preferences(
     )
 
     preferred_topics = await topic_provider.get_topics([t.id for t in input.preferred_topics])
-    user_ids = get_user_ids(info)
+    request_user = get_request_user(info)
 
     model = UserRecommendationPreferencesModel(
-        user_id=user_ids.user_id,  # Integer user id
+        user_id=request_user.user_id,  # Integer user id
         updated_at=datetime.datetime.utcnow(),
         preferred_topics=preferred_topics
     )
 
     model_v2 = UserRecommendationPreferencesModelV2(
-        hashed_user_id=user_ids.hashed_user_id,
+        hashed_user_id=request_user.hashed_user_id,
         updated_at=datetime.datetime.utcnow(),
         preferred_topics=preferred_topics
     )

--- a/app/graphql/util.py
+++ b/app/graphql/util.py
@@ -48,7 +48,7 @@ def get_field_argument(
 def get_request_user(info: Info) -> RequestUser:
     """
     Get user ids from the request headers that are available in the GraphQL context.
-    :param info:
+    :param info: @see https://github.com/Pocket/client-api/blob/main/api-docs/docs/headers.md
     :return:
     """
     headers = info.context.get('request').headers
@@ -58,6 +58,7 @@ def get_request_user(info: Info) -> RequestUser:
         hashed_user_id=headers.get('encodedId'),
         hashed_guid=headers.get('encodedGuid'),
         guid=headers.get('guid'),
+        locale=headers.get('gatewayLangauge'),  # e.g. 'en-US'
     )
 
 

--- a/app/graphql/util.py
+++ b/app/graphql/util.py
@@ -4,7 +4,7 @@ from strawberry.types import Info
 from strawberry.types.nodes import SelectedField
 
 from app.models.api_client import ApiClient
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
 def get_field_argument(
@@ -45,7 +45,7 @@ def get_field_argument(
     return default_value
 
 
-def get_user_ids(info: Info) -> UserIds:
+def get_request_user(info: Info) -> RequestUser:
     """
     Get user ids from the request headers that are available in the GraphQL context.
     :param info:
@@ -53,7 +53,7 @@ def get_user_ids(info: Info) -> UserIds:
     """
     headers = info.context.get('request').headers
 
-    return UserIds(
+    return RequestUser(
         user_id=headers.get('userId'),
         hashed_user_id=headers.get('encodedId'),
         hashed_guid=headers.get('encodedGuid'),

--- a/app/models/request_user.py
+++ b/app/models/request_user.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 
-class UserIds(BaseModel):
+class RequestUser(BaseModel):
     """
     Represents user and session identifiers in internal and encoded representation:
     - user_id: integer user id for Pocket account. Not present on logged-out requests.
@@ -14,3 +14,4 @@ class UserIds(BaseModel):
     hashed_user_id: str = None
     guid: int = None
     hashed_guid: str = None
+    locale: str = None  # e.g. en-US

--- a/tests/functional/data_providers/test_unleash_provider.py
+++ b/tests/functional/data_providers/test_unleash_provider.py
@@ -32,7 +32,8 @@ async def test_get_assignments(pocket_graph_server: TestServer, user_1: RequestU
         'appName': unleash_config.APP_NAME,
         'environment': unleash_config.ENVIRONMENT,
         'userId': user_1.hashed_user_id,
-        'sessionId': user_1.hashed_guid
+        'sessionId': user_1.hashed_guid,
+        'properties': {'locale': user_1.locale}
     }
 
     # pocket_graph_server returns data from `tests/assets/json/unleash_assignments.json`

--- a/tests/functional/data_providers/test_unleash_provider.py
+++ b/tests/functional/data_providers/test_unleash_provider.py
@@ -4,7 +4,7 @@ from aiohttp import ClientError
 from app.data_providers.PocketGraphClientSession import PocketGraphClientSession, PocketGraphConfig
 from app.data_providers.unleash_provider import UnleashProvider, UnleashConfig
 from app.models.unleash_assignment import UnleashAssignmentModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 from tests.mocks.pocket_graph import *
 from tests.mocks.user import user_1
@@ -17,7 +17,7 @@ def _get_pocket_graph_config(pocket_graph_server: TestServer):
 
 
 @pytest.mark.asyncio
-async def test_get_assignments(pocket_graph_server: TestServer, user_1: UserIds):
+async def test_get_assignments(pocket_graph_server: TestServer, user_1: RequestUser):
     unleash_config = UnleashConfig()
 
     async with PocketGraphClientSession(_get_pocket_graph_config(pocket_graph_server)) as pocket_graph_client_session:
@@ -40,7 +40,7 @@ async def test_get_assignments(pocket_graph_server: TestServer, user_1: UserIds)
 
 
 @pytest.mark.asyncio
-async def test_get_assignments_server_error(failing_pocket_graph_server: TestServer, user_1: UserIds):
+async def test_get_assignments_server_error(failing_pocket_graph_server: TestServer, user_1: RequestUser):
     # Assert that an exception is raised when the Pocket GraphQL server responds with a server error.
     with pytest.raises(ClientError) as exception_info:
         async with PocketGraphClientSession(_get_pocket_graph_config(failing_pocket_graph_server)) as client_session:

--- a/tests/functional/graphql/test_get_slate.py
+++ b/tests/functional/graphql/test_get_slate.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
 from unittest.mock import patch
@@ -12,7 +12,7 @@ class TestGetSlate(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.populate_candidate_sets_table()
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )

--- a/tests/functional/graphql/test_get_slate_lineup.py
+++ b/tests/functional/graphql/test_get_slate_lineup.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
 from unittest.mock import patch
@@ -15,7 +15,7 @@ class TestGetSlateLineup(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.populate_candidate_sets_table()
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -14,7 +14,7 @@ from app.data_providers.user_recommendation_preferences_provider import UserReco
 from app.main import app
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.unleash_assignment import UnleashAssignmentModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModel
 from tests.assets.topics import *
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
@@ -76,13 +76,13 @@ HOME_SLATE_LINEUP_QUERY = '''
 class TestHomeSlateLineup(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )
         self.headers = {
-            'userId': str(self.user_ids.user_id),
-            'encodedId': self.user_ids.hashed_user_id,
+            'userId': str(self.request_user.user_id),
+            'encodedId': self.request_user.hashed_user_id,
             'apiId': '94110',
             'consumerKey': 'web-client-consumer-key',
             'applicationName': 'Pocket web-client',
@@ -109,7 +109,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
         mock_get_ranked_corpus_items.return_value = corpus_items_fixture
 
         preferred_topics = [technology_topic, gaming_topic]
-        preferences_fixture = _user_recommendation_preferences_fixture(str(self.user_ids.user_id), preferred_topics)
+        preferences_fixture = _user_recommendation_preferences_fixture(str(self.request_user.user_id), preferred_topics)
         mock_fetch_user_recommendation_preferences.return_value = preferences_fixture
         mock_get_user_impression_caps.return_value = corpus_items_fixture[:6]
         mock_get_all_assignments.return_value = [UnleashAssignmentModel(

--- a/tests/functional/graphql/test_update_user_recommendation_preferences.py
+++ b/tests/functional/graphql/test_update_user_recommendation_preferences.py
@@ -5,7 +5,7 @@ from app.data_providers.user_recommendation_preferences_provider import (
     UserRecommendationPreferencesProviderV2,
 )
 from app.main import app
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from tests.assets.topics import populate_topics, technology_topic, business_topic
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
 
@@ -16,7 +16,7 @@ class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         populate_topics(self.metadata_table)
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )
@@ -48,8 +48,8 @@ class TestUpdateUserRecommendationPreferences(TestDynamoDBBase):
                     },
                 },
                 headers={
-                    'userId': str(self.user_ids.user_id),
-                    'encodedId': self.user_ids.hashed_user_id,
+                    'userId': str(self.request_user.user_id),
+                    'encodedId': self.request_user.hashed_user_id,
                 }
             ).json()
 

--- a/tests/functional/graphql/test_user_reference_resolver.py
+++ b/tests/functional/graphql/test_user_reference_resolver.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 
 from app.data_providers.user_recommendation_preferences_provider import UserRecommendationPreferencesProviderV2
 from app.main import app
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from app.models.user_recommendation_preferences import UserRecommendationPreferencesModelV2
 from tests.assets.topics import populate_topics, business_topic
 from tests.functional.test_dynamodb_base import TestDynamoDBBase
@@ -25,7 +25,7 @@ class TestUserReferenceResolver(TestDynamoDBBase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         populate_topics(self.metadata_table)
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )
@@ -55,7 +55,7 @@ class TestUserReferenceResolver(TestDynamoDBBase):
                         'representations': [
                             {
                                 '__typename': 'User',
-                                'id': self.user_ids.hashed_user_id,
+                                'id': self.request_user.hashed_user_id,
                             },
                         ],
                     },
@@ -68,7 +68,7 @@ class TestUserReferenceResolver(TestDynamoDBBase):
             entities = executed['data']['_entities']
 
             assert len(entities) == 1
-            assert entities[0]['id'] == self.user_ids.hashed_user_id
+            assert entities[0]['id'] == self.request_user.hashed_user_id
             assert entities[0]['recommendationPreferences']['preferredTopics'] == [
                 {'id': business_topic.id, 'name': business_topic.name}
             ]

--- a/tests/mocks/user.py
+++ b/tests/mocks/user.py
@@ -9,5 +9,6 @@ def user_1():
         user_id=1,
         hashed_user_id='1-hashed',
         guid=9876,
-        hashed_guid='9876-hashed'
+        hashed_guid='9876-hashed',
+        locale='en-US',
     )

--- a/tests/mocks/user.py
+++ b/tests/mocks/user.py
@@ -1,11 +1,11 @@
 import pytest
 
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 
 
 @pytest.fixture
 def user_1():
-    return UserIds(
+    return RequestUser(
         user_id=1,
         hashed_user_id='1-hashed',
         guid=9876,

--- a/tests/unit/data_providers/test_home_dispatch.py
+++ b/tests/unit/data_providers/test_home_dispatch.py
@@ -21,7 +21,7 @@ from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_model import CorpusSlateModel
 from app.models.unleash_assignment import UnleashAssignmentModel
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from tests.assets.topics import technology_topic, entertainment_topic, self_improvement_topic
 
 
@@ -48,7 +48,7 @@ class TestHomeDispatch:
     def setup(self):
         global_sdk_config.set_sdk_enabled(False)
 
-        self.user_ids = UserIds(
+        self.request_user = RequestUser(
             user_id=1,
             hashed_user_id='1-hashed',
         )
@@ -91,7 +91,7 @@ class TestHomeDispatch:
             MockSlateProvider(_generate_slate(['Self1'], headline='Self-improvement')),
         ]
 
-        lineup = await self.home_dispatch.get_slate_lineup(user=self.user_ids, slate_count=10, recommendation_count=2)
+        lineup = await self.home_dispatch.get_slate_lineup(user=self.request_user, slate_count=10, recommendation_count=2)
 
         assert [
             ['Tech2', 'Ent4'],
@@ -121,7 +121,7 @@ class TestHomeDispatch:
             MockSlateProvider(_generate_slate(['Tech1', 'Tech2', 'Tech3', 'Tech4'], headline='Technology')),
         ]
 
-        lineup = await self.home_dispatch.get_slate_lineup(user=self.user_ids, slate_count=10, recommendation_count=2)
+        lineup = await self.home_dispatch.get_slate_lineup(user=self.request_user, slate_count=10, recommendation_count=2)
 
         assert [
             ['Tech2', 'Ent4'],

--- a/tests/unit/data_providers/test_user_impression_cap_provider.py
+++ b/tests/unit/data_providers/test_user_impression_cap_provider.py
@@ -5,7 +5,7 @@ from aws_xray_sdk import global_sdk_config
 
 import app.config
 from app.data_providers.user_impression_cap_provider import UserImpressionCapProvider
-from app.models.user_ids import UserIds
+from app.models.request_user import RequestUser
 from tests.mocks.feature_store_mock import FeatureStoreMock
 
 
@@ -30,7 +30,7 @@ class TestUserImpressionCapProvider:
         Test the case where the queried records exist in the Feature Group.
         """
         corpus_items = await self.client.get(
-            user_ids=UserIds(hashed_user_id=self.HASHED_USER_ID)
+            user=RequestUser(hashed_user_id=self.HASHED_USER_ID)
         )
 
         # Assert corpus_items reflect the user_impressions_v2.json fixture data.
@@ -39,6 +39,6 @@ class TestUserImpressionCapProvider:
         assert corpus_items[1].id == '357e1f96-617e-4ece-aa21-a9cc74a457a2'
 
     async def test_get_non_existing_record(self):
-        corpus_items = await self.client.get(user_ids=UserIds(hashed_user_id='i-do-not-exist'))
+        corpus_items = await self.client.get(user=RequestUser(hashed_user_id='i-do-not-exist'))
 
         assert [] == corpus_items


### PR DESCRIPTION
# Goal
Send the user locale to Unleash such that we can use an Unleash strategy to only assign certain locales to an experiment.

A product decision was made that [we can rely on the accept-language header](https://getpocket.atlassian.net/browse/HS-316?focusedCommentId=68493), which our GraphQL gateway sets as the ["gatewayLangauge" header](https://github.com/Pocket/client-api/blob/main/api-docs/docs/headers.md#web-repo-proxy-headers).

## Todos
- [x] Document launch steps in [a Jira ticket](https://getpocket.atlassian.net/browse/HS-349)

## Deployment
- [x] Add a `userInLocale` strategy to the [production feature flag](https://featureflags.readitlater.com/projects/default/features/temp.web.recommendation-api.home.contentv1) with rollout at 0% and locales set to en-US.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-353

## Implementation decisions
- Rename `UserIds` to `RequestUser` now that it includes the user locale. The old name also made it seem like this was a collection of users, as opposed to multiple ids of a single user.
- Naming around locale/language is inconsistent: 'gatewayLangauge' in GraphQL and 'locale' in Unleash. I'm calling it locale internally.

## QA

Steps:
1. Add a `userInLocale` strategy to the [development feature flag](https://featureflags.getpocket.dev/projects/default/features/temp.web.recommendation-api.home.contentv1) with rollout at 100% and locales set to en-US.
2. Start the `main Pocket-dev` runconfiguration in PyCharm.
3. Make a request:
```shell
curl --location --request POST 'http://localhost:8000' \
--header 'gatewayLangauge: en-US' \
--header 'userId: <your user id>' \
--header 'encodedId: <your hashed user id>' \
--header 'encodedGuid;' \
--header 'apiId: 1234' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": "query PostmanHomeSlateLineup { homeSlateLineup { id slates { headline moreLink { url text } recommendationReasonType recommendations(count: 6) { corpusItem { id } reason { name type } } } } }",
    "variables": null,
    "operationName": "PostmanHomeSlateLineup"
}'
```

- [x] Pocket Hits slate is included if `gatewayLangauge` is en-US
- [x] Pocket Hits slate not is included if `gatewayLangauge` is en
- [x] Pocket Hits slate not is included if `gatewayLangauge` is missing
- [x] Pocket Hits slate not is included if rollout is set to 0% and `gatewayLangauge` is en-US