### PR TITLE
fix(Home): Pocket Hits date was wrong [HS-352]

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -41,6 +41,7 @@ ujson = "*"
 httptools = "*"
 aio-snowplow-tracker = "*"
 strawberry-graphql = {extras = ["fastapi"], version = "*"}
+pytz = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6bccec0e0473953c819bc2781f01816344d1ef911dfbc26450d3fc5dbf0077d0"
+            "sha256": "0f83330a1dd46777a9c17f979b1c4622368a271b20bf78241efd845d4a8f88f9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -192,7 +192,7 @@
                 "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
                 "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==22.1.0"
         },
         "aws-xray-sdk": {
@@ -407,7 +407,7 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==3.4"
         },
         "importlib-resources": {
@@ -585,30 +585,31 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c",
-                "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc",
-                "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e",
-                "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26",
-                "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec",
-                "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286",
-                "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045",
-                "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec",
-                "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8",
-                "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c",
-                "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca",
-                "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22",
-                "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a",
-                "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96",
-                "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc",
-                "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1",
-                "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07",
-                "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6",
-                "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b",
-                "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5",
-                "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"
+                "sha256:06579d46d8ad69529b28f88711191a7fe7103c92d04a9f338dc754f71b92efa0",
+                "sha256:1d0620474d509172e1c50b79d5626bfe1899f174bf650186a50c6ce31289ff52",
+                "sha256:2032d971711643049b4f2c3ca5155a855d507d73bad26dac8d4349e5c5dd6758",
+                "sha256:2c641111c3f110379bb9001dbb26b34eb8cafab3d0fa855dc161c391461a4aab",
+                "sha256:327f99800d04a9abcf580daecfd6dd4bfdb4a7e61c71bf2cd1189ef1ca44bade",
+                "sha256:39f15ad754384e744ac8b00805913bfa66c41131faaa3e4c45c4af0731f3e8f6",
+                "sha256:4c58bd93c4d502f52938fccdbe6c9d70df3a585c6b39d900fab5f76b604282aa",
+                "sha256:62a41037387ae849a493cd945e22b34d167a843d57f75b07dbfad6d96cef485c",
+                "sha256:62b704f18526a8fc243152de8f3f40ae39c5172baff10f50c0c5d5331d6f2342",
+                "sha256:6df99c3578dc4eb33f3eb26bc28277ab40a720b71649d940bff9c1f704377772",
+                "sha256:6ef7430e45c5fa0bb6c361cada4a08ed9c184b5ed086815a85c3bc8c5054566b",
+                "sha256:73b2db09fe15b6e444c0bd566a125a385ca6493456224ce8b367d734f079f576",
+                "sha256:73d4ec2997716af3c8f28f7e3d3a565d273a598982d2fe95639e07ce4db5da45",
+                "sha256:73e3e2fd9da009d558050697cc22ad689f89a14a2ef2e67304628a913e59c947",
+                "sha256:890f577aec554f142e01daf890221d10e4f93a9b1107998d631d3f075b55e8f8",
+                "sha256:8a34a2a8b220247658f7ced871197c390b3a6371d796a5869ab1c62abe0be527",
+                "sha256:8bc23e9ddcb523c3ffb4d712aa0bd5bc67b34ff4e2b23fb557012171bdb4013a",
+                "sha256:945297fc344fef4d540135180ce7babeb2291d124698cc6282f3eac624aa5e82",
+                "sha256:aaa869d9199d7d4c70a57678aff21654cc179c0c32bcfde87f1d65d0ff47e520",
+                "sha256:bc33fc20ddfd89b86b7710142963490d8c4ee8307ed6cc5e189a58fa72390eb9",
+                "sha256:cfe6d8b293d123255fd3b475b5f4e851eb5cbaee2064c8933aa27344381744ae",
+                "sha256:d16ac5ab3d9db78fed40c884d67079524e4cf8276639211ad9e6fa73e727727e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.18.1"
+            "version": "==0.19.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -630,6 +631,14 @@
                 "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"
             ],
             "version": "==0.0.5"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
+                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
+            ],
+            "index": "pypi",
+            "version": "==2022.5"
         },
         "pyyaml": {
             "hashes": [
@@ -756,11 +765,11 @@
                 "fastapi"
             ],
             "hashes": [
-                "sha256:4b36ef85654d70c22208d99577b287d805bbd9626d93906aa9021967c3d502a9",
-                "sha256:b6ba148a71752218dc2d19d686a45fb650676b9d90f1331802542ef9e5d79ae2"
+                "sha256:5428c314e9d605ae0b4aba7193ead2ae664f5f242fb69c53a69a7e11adcca487",
+                "sha256:7955f647afb461ae73cfc9f469a8a77bc539e0ddc761f921a2e7028860157269"
             ],
             "index": "pypi",
-            "version": "==0.137.1"
+            "version": "==0.138.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -920,56 +929,77 @@
         },
         "websockets": {
             "hashes": [
-                "sha256:07cdc0a5b2549bcfbadb585ad8471ebdc7bdf91e32e34ae3889001c1c106a6af",
-                "sha256:210aad7fdd381c52e58777560860c7e6110b6174488ef1d4b681c08b68bf7f8c",
-                "sha256:28dd20b938a57c3124028680dc1600c197294da5db4292c76a0b48efb3ed7f76",
-                "sha256:2f94fa3ae454a63ea3a19f73b95deeebc9f02ba2d5617ca16f0bbdae375cda47",
-                "sha256:31564a67c3e4005f27815634343df688b25705cccb22bc1db621c781ddc64c69",
-                "sha256:347974105bbd4ea068106ec65e8e8ebd86f28c19e529d115d89bd8cc5cda3079",
-                "sha256:379e03422178436af4f3abe0aa8f401aa77ae2487843738542a75faf44a31f0c",
-                "sha256:3eda1cb7e9da1b22588cefff09f0951771d6ee9fa8dbe66f5ae04cc5f26b2b55",
-                "sha256:51695d3b199cd03098ae5b42833006a0f43dc5418d3102972addc593a783bc02",
-                "sha256:54c000abeaff6d8771a4e2cef40900919908ea7b6b6a30eae72752607c6db559",
-                "sha256:5b936bf552e4f6357f5727579072ff1e1324717902127ffe60c92d29b67b7be3",
-                "sha256:6075fd24df23133c1b078e08a9b04a3bc40b31a8def4ee0b9f2c8865acce913e",
-                "sha256:661f641b44ed315556a2fa630239adfd77bd1b11cb0b9d96ed8ad90b0b1e4978",
-                "sha256:6ea6b300a6bdd782e49922d690e11c3669828fe36fc2471408c58b93b5535a98",
-                "sha256:6ed1d6f791eabfd9808afea1e068f5e59418e55721db8b7f3bfc39dc831c42ae",
-                "sha256:7934e055fd5cd9dee60f11d16c8d79c4567315824bacb1246d0208a47eca9755",
-                "sha256:7ab36e17af592eec5747c68ef2722a74c1a4a70f3772bc661079baf4ae30e40d",
-                "sha256:7f6d96fdb0975044fdd7953b35d003b03f9e2bcf85f2d2cf86285ece53e9f991",
-                "sha256:83e5ca0d5b743cde3d29fda74ccab37bdd0911f25bd4cdf09ff8b51b7b4f2fa1",
-                "sha256:85506b3328a9e083cc0a0fb3ba27e33c8db78341b3eb12eb72e8afd166c36680",
-                "sha256:8af75085b4bc0b5c40c4a3c0e113fa95e84c60f4ed6786cbb675aeb1ee128247",
-                "sha256:8b1359aba0ff810d5830d5ab8e2c4a02bebf98a60aa0124fb29aa78cfdb8031f",
-                "sha256:8fbd7d77f8aba46d43245e86dd91a8970eac4fb74c473f8e30e9c07581f852b2",
-                "sha256:907e8247480f287aa9bbc9391bd6de23c906d48af54c8c421df84655eef66af7",
-                "sha256:93d5ea0b5da8d66d868b32c614d2b52d14304444e39e13a59566d4acb8d6e2e4",
-                "sha256:97bc9d41e69a7521a358f9b8e44871f6cdeb42af31815c17aed36372d4eec667",
-                "sha256:994cdb1942a7a4c2e10098d9162948c9e7b235df755de91ca33f6e0481366fdb",
-                "sha256:a141de3d5a92188234afa61653ed0bbd2dde46ad47b15c3042ffb89548e77094",
-                "sha256:a1e15b230c3613e8ea82c9fc6941b2093e8eb939dd794c02754d33980ba81e36",
-                "sha256:aad5e300ab32036eb3fdc350ad30877210e2f51bceaca83fb7fef4d2b6c72b79",
-                "sha256:b529fdfa881b69fe563dbd98acce84f3e5a67df13de415e143ef053ff006d500",
-                "sha256:b9c77f0d1436ea4b4dc089ed8335fa141e6a251a92f75f675056dac4ab47a71e",
-                "sha256:bb621ec2dbbbe8df78a27dbd9dd7919f9b7d32a73fafcb4d9252fc4637343582",
-                "sha256:c7250848ce69559756ad0086a37b82c986cd33c2d344ab87fea596c5ac6d9442",
-                "sha256:c8d1d14aa0f600b5be363077b621b1b4d1eb3fbf90af83f9281cda668e6ff7fd",
-                "sha256:d1655a6fc7aecd333b079d00fb3c8132d18988e47f19740c69303bf02e9883c6",
-                "sha256:d6353ba89cfc657a3f5beabb3b69be226adbb5c6c7a66398e17809b0ce3c4731",
-                "sha256:da4377904a3379f0c1b75a965fff23b28315bcd516d27f99a803720dfebd94d4",
-                "sha256:e49ea4c1a9543d2bd8a747ff24411509c29e4bdcde05b5b0895e2120cb1a761d",
-                "sha256:e4e08305bfd76ba8edab08dcc6496f40674f44eb9d5e23153efa0a35750337e8",
-                "sha256:e6fa05a680e35d0fcc1470cb070b10e6fe247af54768f488ed93542e71339d6f",
-                "sha256:e7e6f2d6fd48422071cc8a6f8542016f350b79cc782752de531577d35e9bd677",
-                "sha256:e904c0381c014b914136c492c8fa711ca4cced4e9b3d110e5e7d436d0fc289e8",
-                "sha256:ec2b0ab7edc8cd4b0eb428b38ed89079bdc20c6bdb5f889d353011038caac2f9",
-                "sha256:ef5ce841e102278c1c2e98f043db99d6755b1c58bde475516aef3a008ed7f28e",
-                "sha256:f351c7d7d92f67c0609329ab2735eee0426a03022771b00102816a72715bb00b",
-                "sha256:fab7c640815812ed5f10fbee7abbf58788d602046b7bb3af9b1ac753a6d5e916",
-                "sha256:fc06cc8073c8e87072138ba1e431300e2d408f054b27047d047b549455066ff4"
+                "sha256:00213676a2e46b6ebf6045bc11d0f529d9120baa6f58d122b4021ad92adabd41",
+                "sha256:00c870522cdb69cd625b93f002961ffb0c095394f06ba8c48f17eef7c1541f96",
+                "sha256:0154f7691e4fe6c2b2bc275b5701e8b158dae92a1ab229e2b940efe11905dff4",
+                "sha256:05a7233089f8bd355e8cbe127c2e8ca0b4ea55467861906b80d2ebc7db4d6b72",
+                "sha256:09a1814bb15eff7069e51fed0826df0bc0702652b5cb8f87697d469d79c23576",
+                "sha256:0cff816f51fb33c26d6e2b16b5c7d48eaa31dae5488ace6aae468b361f422b63",
+                "sha256:185929b4808b36a79c65b7865783b87b6841e852ef5407a2fb0c03381092fa3b",
+                "sha256:2fc8709c00704194213d45e455adc106ff9e87658297f72d544220e32029cd3d",
+                "sha256:33d69ca7612f0ddff3316b0c7b33ca180d464ecac2d115805c044bf0a3b0d032",
+                "sha256:389f8dbb5c489e305fb113ca1b6bdcdaa130923f77485db5b189de343a179393",
+                "sha256:38ea7b82bfcae927eeffc55d2ffa31665dc7fec7b8dc654506b8e5a518eb4d50",
+                "sha256:3d3cac3e32b2c8414f4f87c1b2ab686fa6284a980ba283617404377cd448f631",
+                "sha256:40e826de3085721dabc7cf9bfd41682dadc02286d8cf149b3ad05bff89311e4f",
+                "sha256:4239b6027e3d66a89446908ff3027d2737afc1a375f8fd3eea630a4842ec9a0c",
+                "sha256:45ec8e75b7dbc9539cbfafa570742fe4f676eb8b0d3694b67dabe2f2ceed8aa6",
+                "sha256:47a2964021f2110116cc1125b3e6d87ab5ad16dea161949e7244ec583b905bb4",
+                "sha256:48c08473563323f9c9debac781ecf66f94ad5a3680a38fe84dee5388cf5acaf6",
+                "sha256:4c6d2264f485f0b53adf22697ac11e261ce84805c232ed5dbe6b1bcb84b00ff0",
+                "sha256:4f72e5cd0f18f262f5da20efa9e241699e0cf3a766317a17392550c9ad7b37d8",
+                "sha256:56029457f219ade1f2fc12a6504ea61e14ee227a815531f9738e41203a429112",
+                "sha256:5c1289596042fad2cdceb05e1ebf7aadf9995c928e0da2b7a4e99494953b1b94",
+                "sha256:62e627f6b6d4aed919a2052efc408da7a545c606268d5ab5bfab4432734b82b4",
+                "sha256:74de2b894b47f1d21cbd0b37a5e2b2392ad95d17ae983e64727e18eb281fe7cb",
+                "sha256:7c584f366f46ba667cfa66020344886cf47088e79c9b9d39c84ce9ea98aaa331",
+                "sha256:7d27a7e34c313b3a7f91adcd05134315002aaf8540d7b4f90336beafaea6217c",
+                "sha256:7d3f0b61c45c3fa9a349cf484962c559a8a1d80dae6977276df8fd1fa5e3cb8c",
+                "sha256:82ff5e1cae4e855147fd57a2863376ed7454134c2bf49ec604dfe71e446e2193",
+                "sha256:84bc2a7d075f32f6ed98652db3a680a17a4edb21ca7f80fe42e38753a58ee02b",
+                "sha256:884be66c76a444c59f801ac13f40c76f176f1bfa815ef5b8ed44321e74f1600b",
+                "sha256:8a5cc00546e0a701da4639aa0bbcb0ae2bb678c87f46da01ac2d789e1f2d2038",
+                "sha256:8dc96f64ae43dde92530775e9cb169979f414dcf5cff670455d81a6823b42089",
+                "sha256:8f38706e0b15d3c20ef6259fd4bc1700cd133b06c3c1bb108ffe3f8947be15fa",
+                "sha256:90fcf8929836d4a0e964d799a58823547df5a5e9afa83081761630553be731f9",
+                "sha256:931c039af54fc195fe6ad536fde4b0de04da9d5916e78e55405436348cfb0e56",
+                "sha256:932af322458da7e4e35df32f050389e13d3d96b09d274b22a7aa1808f292fee4",
+                "sha256:942de28af58f352a6f588bc72490ae0f4ccd6dfc2bd3de5945b882a078e4e179",
+                "sha256:9bc42e8402dc5e9905fb8b9649f57efcb2056693b7e88faa8fb029256ba9c68c",
+                "sha256:a7a240d7a74bf8d5cb3bfe6be7f21697a28ec4b1a437607bae08ac7acf5b4882",
+                "sha256:a9f9a735deaf9a0cadc2d8c50d1a5bcdbae8b6e539c6e08237bc4082d7c13f28",
+                "sha256:ae5e95cfb53ab1da62185e23b3130e11d64431179debac6dc3c6acf08760e9b1",
+                "sha256:b029fb2032ae4724d8ae8d4f6b363f2cc39e4c7b12454df8df7f0f563ed3e61a",
+                "sha256:b0d15c968ea7a65211e084f523151dbf8ae44634de03c801b8bd070b74e85033",
+                "sha256:b343f521b047493dc4022dd338fc6db9d9282658862756b4f6fd0e996c1380e1",
+                "sha256:b627c266f295de9dea86bd1112ed3d5fafb69a348af30a2422e16590a8ecba13",
+                "sha256:b9968694c5f467bf67ef97ae7ad4d56d14be2751000c1207d31bf3bb8860bae8",
+                "sha256:ba089c499e1f4155d2a3c2a05d2878a3428cf321c848f2b5a45ce55f0d7d310c",
+                "sha256:bbccd847aa0c3a69b5f691a84d2341a4f8a629c6922558f2a70611305f902d74",
+                "sha256:bc0b82d728fe21a0d03e65f81980abbbcb13b5387f733a1a870672c5be26edab",
+                "sha256:c57e4c1349fbe0e446c9fa7b19ed2f8a4417233b6984277cce392819123142d3",
+                "sha256:c94ae4faf2d09f7c81847c63843f84fe47bf6253c9d60b20f25edfd30fb12588",
+                "sha256:c9b27d6c1c6cd53dc93614967e9ce00ae7f864a2d9f99fe5ed86706e1ecbf485",
+                "sha256:d210abe51b5da0ffdbf7b43eed0cfdff8a55a1ab17abbec4301c9ff077dd0342",
+                "sha256:d58804e996d7d2307173d56c297cf7bc132c52df27a3efaac5e8d43e36c21c48",
+                "sha256:d6a4162139374a49eb18ef5b2f4da1dd95c994588f5033d64e0bbfda4b6b6fcf",
+                "sha256:da39dd03d130162deb63da51f6e66ed73032ae62e74aaccc4236e30edccddbb0",
+                "sha256:db3c336f9eda2532ec0fd8ea49fef7a8df8f6c804cdf4f39e5c5c0d4a4ad9a7a",
+                "sha256:dd500e0a5e11969cdd3320935ca2ff1e936f2358f9c2e61f100a1660933320ea",
+                "sha256:dd9becd5fe29773d140d68d607d66a38f60e31b86df75332703757ee645b6faf",
+                "sha256:e0cb5cc6ece6ffa75baccfd5c02cffe776f3f5c8bf486811f9d3ea3453676ce8",
+                "sha256:e23173580d740bf8822fd0379e4bf30aa1d5a92a4f252d34e893070c081050df",
+                "sha256:e3a686ecb4aa0d64ae60c9c9f1a7d5d46cab9bfb5d91a2d303d00e2cd4c4c5cc",
+                "sha256:e789376b52c295c4946403bd0efecf27ab98f05319df4583d3c48e43c7342c2f",
+                "sha256:edc344de4dac1d89300a053ac973299e82d3db56330f3494905643bb68801269",
+                "sha256:eef610b23933c54d5d921c92578ae5f89813438fded840c2e9809d378dc765d3",
+                "sha256:f2c38d588887a609191d30e902df2a32711f708abfd85d318ca9b367258cfd0c",
+                "sha256:f55b5905705725af31ccef50e55391621532cd64fbf0bc6f4bac935f0fccec46",
+                "sha256:f5fc088b7a32f244c519a048c170f14cf2251b849ef0e20cbbb0fdf0fdaf556f",
+                "sha256:fe10ddc59b304cb19a1bdf5bd0a7719cbbc9fbdd57ac80ed436b709fcf889106",
+                "sha256:ff64a1d38d156d429404aaa84b27305e957fd10c30e5880d1765c9480bea490f"
             ],
-            "version": "==10.3"
+            "version": "==10.4"
         },
         "wrapt": {
             "hashes": [
@@ -1254,7 +1284,7 @@
                 "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
                 "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==22.1.0"
         },
         "aws-secretsmanager-caching": {
@@ -1286,11 +1316,11 @@
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:4a70b320244752a4dce8239329c9a9cede4a0781e924314f621ec872afe23450",
-                "sha256:bffbb183adb645a4a6a436c24386f4c33a3f42e422d1fa1bf6b5fb30c5bc0f27"
+                "sha256:830b876ca9ef0a0bbe3b979f50c15d0f33e410ca3114dceaf30ceb88ffb15130",
+                "sha256:9720d8b27fd07868ce1718a093b02f6734e28c6b7d714ecef6fdfa6af026dbb8"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==1.27.96"
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==1.28.4"
         },
         "certifi": {
             "hashes": [
@@ -1366,11 +1396,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337",
-                "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"
+                "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41",
+                "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.0rc9"
+            "version": "==1.0.0"
         },
         "freezegun": {
             "hashes": [
@@ -1474,7 +1504,7 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==3.4"
         },
         "iniconfig": {
@@ -1723,11 +1753,11 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:42a99eaa9e9312e723e4b3793e23c5be155cdacde20cb554ff0d74fd6780808b",
-                "sha256:b65355b9926ce0cdf5f9949b2c310937f6f44b2e56292243888041dce60bc47b"
+                "sha256:38c3d0d5c20a5516eead8860be264063a8ceb5997a7a890599174ab96915a7b4",
+                "sha256:c9a49c024376e425c12ea72332ec4448c9bb1544fdb8f71a40e889e43f296109"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==0.14.7"
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.15.1"
         },
         "typing-extensions": {
             "hashes": [

--- a/app/data_providers/slate_providers/pocket_hits_slate_provider.py
+++ b/app/data_providers/slate_providers/pocket_hits_slate_provider.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
+import pytz
 
 from app.data_providers.slate_providers.slate_provider import SlateProvider
 from app.models.recommendation_reason_type import RecommendationReasonType
@@ -17,7 +18,8 @@ class PocketHitsSlateProvider(SlateProvider):
 
     @property
     def subheadline(self) -> str:
-        dt = datetime.now()
+        # The date is supposed to progress at 10AM EDT.
+        dt = datetime.now(tz=pytz.timezone('America/New_York')) - timedelta(hours=10)
         return f'{dt:%A}, {dt:%B} {dt.day}'
 
     @property

--- a/app/data_providers/slate_providers/pocket_hits_slate_provider.py
+++ b/app/data_providers/slate_providers/pocket_hits_slate_provider.py
@@ -18,8 +18,8 @@ class PocketHitsSlateProvider(SlateProvider):
 
     @property
     def subheadline(self) -> str:
-        # The date is supposed to progress at 10AM EDT.
-        dt = datetime.now(tz=pytz.timezone('America/New_York')) - timedelta(hours=10)
+        # The date is supposed to progress at 3AM EDT.
+        dt = datetime.now(tz=pytz.timezone('America/New_York')) - timedelta(hours=3)
         return f'{dt:%A}, {dt:%B} {dt.day}'
 
     @property

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -28,7 +28,6 @@ from app.singletons import (
 async def resolve_home_slate_lineup(root, info: Info) -> CorpusSlateLineup:
     user = get_user_ids(info)
     api_client = get_pocket_client(info)
-    unleash_provider = UnleashProvider(PocketGraphClientSession(PocketGraphConfig()), unleash_config=UnleashConfig())
 
     slate_count = int(get_field_argument(
         fields=info.selected_fields,
@@ -42,23 +41,26 @@ async def resolve_home_slate_lineup(root, info: Info) -> CorpusSlateLineup:
         argument_name='count',
         default_value=DEFAULT_RECOMMENDATION_COUNT))
 
-    slate_lineup_model = await HomeDispatch(
-        corpus_client=corpus_client,
-        preferences_provider=user_recommendation_preferences_provider,
-        user_impression_cap_provider=user_impression_cap_provider,
-        topic_provider=topic_provider,
-        for_you_slate_provider=ForYouSlateProvider(corpus_client),
-        recommended_reads_slate_provider=RecommendedReadsSlateProvider(corpus_client),
-        topic_slate_providers=TopicSlateProviderFactory(corpus_client),
-        collection_slate_provider=CollectionSlateProvider(corpus_client),
-        pocket_hits_slate_provider=PocketHitsSlateProvider(corpus_client),
-        life_hacks_slate_provider=LifeHacksSlateProvider(corpus_client),
-        unleash_provider=unleash_provider,
-    ).get_slate_lineup(
-        user=user,
-        slate_count=slate_count,
-        recommendation_count=recommendation_count,
-    )
+    async with PocketGraphClientSession(PocketGraphConfig()) as graph_client_session:
+        unleash_provider = UnleashProvider(graph_client_session, unleash_config=UnleashConfig())
+
+        slate_lineup_model = await HomeDispatch(
+            corpus_client=corpus_client,
+            preferences_provider=user_recommendation_preferences_provider,
+            user_impression_cap_provider=user_impression_cap_provider,
+            topic_provider=topic_provider,
+            for_you_slate_provider=ForYouSlateProvider(corpus_client),
+            recommended_reads_slate_provider=RecommendedReadsSlateProvider(corpus_client),
+            topic_slate_providers=TopicSlateProviderFactory(corpus_client),
+            collection_slate_provider=CollectionSlateProvider(corpus_client),
+            pocket_hits_slate_provider=PocketHitsSlateProvider(corpus_client),
+            life_hacks_slate_provider=LifeHacksSlateProvider(corpus_client),
+            unleash_provider=unleash_provider,
+        ).get_slate_lineup(
+            user=user,
+            slate_count=slate_count,
+            recommendation_count=recommendation_count,
+        )
 
     slate_lineup_tracker = SnowplowCorpusSlateLineupTracker(
         tracker=create_snowplow_tracker(), snowplow_config=SnowplowConfig())

--- a/tests/unit/data_providers/test_pocket_hits_slate_provider.py
+++ b/tests/unit/data_providers/test_pocket_hits_slate_provider.py
@@ -27,16 +27,16 @@ class TestPocketHitsSlateProvider:
 
         assert RecommendationReasonType.POCKET_HITS == slate.recommendation_reason_type
 
-    @freeze_time("2022-10-25 13:00:00", tz_offset=0)  # Tue 1pm Oct 25th, 2022 UTC was Tue 9am Oct 25th EDT
+    @freeze_time("2022-10-25 6:00:00", tz_offset=0)  # Tue 6am Oct 25th, 2022 UTC was Tue 2am Oct 25th EDT
     async def test_headline(self):
         slate = await self.slate_provider.get_slate()
 
         assert slate.headline == 'Today’s Pocket Hits'
-        assert slate.subheadline == 'Monday, October 24'
+        assert slate.subheadline == 'Monday, October 24'  # At 2am EDT the date should be the previous day.
 
-    @freeze_time("2022-10-25 14:00:00", tz_offset=0)  # Tue 2pm Oct 25th, 2022 UTC was Tue 10am Oct 25th EDT
+    @freeze_time("2022-10-25 7:00:00", tz_offset=0)  # Tue 2pm Oct 25th, 2022 UTC was Tue 3am Oct 25th EDT
     async def test_headline(self):
         slate = await self.slate_provider.get_slate()
 
         assert slate.headline == 'Today’s Pocket Hits'
-        assert slate.subheadline == 'Tuesday, October 25'
+        assert slate.subheadline == 'Tuesday, October 25'  # At 3am EDT the date should be the current day.

--- a/tests/unit/data_providers/test_pocket_hits_slate_provider.py
+++ b/tests/unit/data_providers/test_pocket_hits_slate_provider.py
@@ -27,9 +27,16 @@ class TestPocketHitsSlateProvider:
 
         assert RecommendationReasonType.POCKET_HITS == slate.recommendation_reason_type
 
-    @freeze_time("2022-10-24 16:00:00")  # Oct 24th, 2022 was a Monday
+    @freeze_time("2022-10-25 13:00:00", tz_offset=0)  # Tue 1pm Oct 25th, 2022 UTC was Tue 9am Oct 25th EDT
     async def test_headline(self):
         slate = await self.slate_provider.get_slate()
 
         assert slate.headline == 'Today’s Pocket Hits'
         assert slate.subheadline == 'Monday, October 24'
+
+    @freeze_time("2022-10-25 14:00:00", tz_offset=0)  # Tue 2pm Oct 25th, 2022 UTC was Tue 10am Oct 25th EDT
+    async def test_headline(self):
+        slate = await self.slate_provider.get_slate()
+
+        assert slate.headline == 'Today’s Pocket Hits'
+        assert slate.subheadline == 'Tuesday, October 25'


### PR DESCRIPTION
# Goal
The publishing day for Pocket Hits slate on Home as displayed in the subheadline should start at 3am EDT.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/HS-352

## Implementation Decisions
- The `pytz` library seems to be the conventional way in Python to get timezones. Python 3.9 introduces [zoneinfo](https://docs.python.org/3.9/library/zoneinfo.html#module-zoneinfo) that can replace this library.