### PR TITLE
feat(Home): Log experiment outcome

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -147,6 +147,7 @@ class HomeDispatch:
         else:
             slates += [self.recommended_reads_slate_provider.get_slate()]
 
+        logging.warning(f'User with locale={user.locale} was assigned to experiment: {contentv1_assignment}')
         if contentv1_assignment is not None and contentv1_assignment.variant == 'treatment':
             slates += [
                 self.pocket_hits_slate_provider.get_slate(),


### PR DESCRIPTION
# Goal
Log the Home user locale and experiment to find out why users are not getting assigned to the Home content v1 experiment.

# Reference

Slack thread: https://pocket.slack.com/archives/C03QR6YN2HF/p1667414234636919

# QA
When locale=en-US:
> WARNING:root:User with locale=en-US was assigned to experiment: assigned=True name='temp.web.recommendation-api.home.contentv1' payload=None variant='treatment'

When locale is en-CA:
> WARNING:root:User with locale=en-CA was assigned to experiment: None