### PR TITLE
fix(Home): Typo in gatewayLanguage header

### DIFF
--- a/app/graphql/util.py
+++ b/app/graphql/util.py
@@ -58,7 +58,7 @@ def get_request_user(info: Info) -> RequestUser:
         hashed_user_id=headers.get('encodedId'),
         hashed_guid=headers.get('encodedGuid'),
         guid=headers.get('guid'),
-        locale=headers.get('gatewayLangauge'),  # e.g. 'en-US'
+        locale=headers.get('gatewayLanguage'),  # e.g. 'en-US'
     )
 
 


### PR DESCRIPTION
# Goal
Fix typo to correctly get the `gatewayLanguage` header.