### PR TITLE
Add publisher url to fedration key for syndicated article

### DIFF
--- a/app/graphql/syndicated_article.py
+++ b/app/graphql/syndicated_article.py
@@ -21,3 +21,4 @@ class SyndicatedArticle:
     @classmethod
     def resolve_reference(cls, itemId: strawberry.ID, publisherUrl: str):
         return SyndicatedArticle(itemId=itemId, publisherUrl=publisherUrl)
+

--- a/app/graphql/syndicated_article.py
+++ b/app/graphql/syndicated_article.py
@@ -6,10 +6,10 @@ from app.graphql.corpus_recommendation import CorpusRecommendation
 from app.graphql.resolvers.item2item_resolvers import resolve_end_of_article, resolve_right_rail
 
 
-@strawberry.federation.type(keys=["itemId"])
+@strawberry.federation.type(keys=["itemId", "publisherUrl"])
 class SyndicatedArticle:
     itemId: strawberry.ID  # this corresponds to Snowflake resolved_id
-    publisherUrl: str = strawberry.federation.field(shareable=True)
+    publisherUrl: str
 
     relatedEndOfArticle: List[CorpusRecommendation] = strawberry.field(
         resolver=resolve_end_of_article,


### PR DESCRIPTION
# Goal
Fix graphql schema to provide syndicated article publisher URL to rec API

Not sure if it will work though, we might need to add `sharable` attribute to the original `SyndicateArticle` in `syndicated` subgraph https://www.apollographql.com/docs/federation/federated-types/federated-directives#shareable

