### PR TITLE
fix(Build): ERROR: npm v9.1.1 is known not to run on Node.js v14.5.0.

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -53,7 +53,8 @@ phases:
       - tfenv install
       - tfenv use $(cat .terraform-version)
 
-      - npm install -g npm@latest
+      # NPM v9 is incompatible with Node 14, which is used as the base image for this build.
+      - npm install -g npm@"<9.0.0"
       - npm ci
       # synthesize the js into terraform json with the proper node environment
       - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'


### PR DESCRIPTION
# Goal
Fix error that causes the [PR build to fail](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/996905175585/projects/RecommendationAPI-PRs-Prod/build/RecommendationAPI-PRs-Prod%3A5008e061-08b7-42e5-8f36-8bff66ec9c94/?region=us-east-1):
> ERROR: npm v9.1.1 is known not to run on Node.js v14.5.0.

## Reference

Slack thread:
* https://pocket.slack.com/archives/C02JZ4TRF0S/p1668036357296579

## Implementation Decisions
