### PR TITLE
Add fallback to random articles for related

### DIFF
--- a/app/data_providers/item2item.py
+++ b/app/data_providers/item2item.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 from qdrant_client.http import AsyncApis
@@ -80,6 +81,8 @@ class Item2ItemRecommender:
                         with_vector=False,
                         with_payload=True
                     ))).result.points
+                logging.warning(f'Related: article is not found, fallback to Qdrant scroll method. '
+                                f'resolved_id: {resolved_id}, filter: {query_filter}')
             else:
                 raise
 

--- a/tests/functional/graphql/test_related.py
+++ b/tests/functional/graphql/test_related.py
@@ -35,43 +35,76 @@ def populate_qdrant():
         return test_data
 
 
+def syndicated_json(item_id: str, pub_url: str):
+    return {
+        'query': '''
+            query ($representations: [_Any!]!) {
+              _entities(representations: $representations) {
+                ... on SyndicatedArticle {
+                    itemId
+                    publisherUrl
+                    relatedEndOfArticle(count: 3) {
+                        id
+                        corpusItem {
+                          id
+                        }
+                    }
+                }
+              }
+            }
+        ''',
+        'variables': {
+            'representations': [
+                {
+                    '__typename': 'SyndicatedArticle',
+                    'itemId': item_id,
+                    'publisherUrl': pub_url,
+                },
+            ],
+        },
+    }
+
+def publisher_json(item_id: str, pub_url: str):
+    return {
+        'query': '''
+            query ($representations: [_Any!]!) {
+              _entities(representations: $representations) {
+                ... on SyndicatedArticle {
+                    itemId
+                    publisherUrl
+                    relatedRightRail(count: 3) {
+                        id
+                        corpusItem {
+                          id
+                        }
+                    }
+                }
+              }
+            }
+        ''',
+        'variables': {
+            'representations': [
+                {
+                    '__typename': 'SyndicatedArticle',
+                    'itemId': item_id,
+                    'publisherUrl': pub_url,
+                },
+            ],
+        },
+    }
+
 class TestGraphQLRelated(TestCase):
     @classmethod
     def setUpClass(cls):
-        populate_qdrant()
+        test_data = populate_qdrant()
+        cls.art_by_corpus_id = {d['payload'] ['corpus_item_id']: d['payload'] for d in test_data}
 
     def test_related_end_of_article_basic(self):
         item_id = '3727511744'
         pub_url = 'https://time.com/6223012/workplaces-of-the-future/'
 
         with TestClient(app) as client:
-            response = client.post("/", json={
-                    'query': '''
-                        query ($representations: [_Any!]!) {
-                          _entities(representations: $representations) {
-                            ... on SyndicatedArticle {
-                                itemId
-                                publisherUrl
-                                relatedEndOfArticle(count: 3) {
-                                    id
-                                    corpusItem {
-                                      id
-                                    }
-                                }
-                            }
-                          }
-                        }
-                    ''',
-                    'variables': {
-                        'representations': [
-                            {
-                                '__typename': 'SyndicatedArticle',
-                                'itemId': item_id,
-                                'publisherUrl': pub_url,
-                            },
-                        ],
-                    },
-                }).json()
+            response = client.post("/", json=syndicated_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
             entity = response['data']['_entities'][0]
@@ -91,34 +124,7 @@ class TestGraphQLRelated(TestCase):
         pub_url = 'https://psyche.co/ideas/are-successful-authors-creative-geniuses-or-literary-labourers'
 
         with TestClient(app) as client:
-            response = client.post("/", json={
-                'query': '''
-                        query ($representations: [_Any!]!) {
-                          _entities(representations: $representations) {
-                            ... on SyndicatedArticle {
-                                itemId
-                                publisherUrl
-                                relatedRightRail(count: 3) {
-                                    id
-                                    corpusItem {
-                                      id
-                                    }
-                                }
-                            }
-                          }
-                        }
-                    ''',
-                    'variables': {
-                        'representations': [
-                            {
-                                '__typename': 'SyndicatedArticle',
-                                'itemId': item_id,
-                                'publisherUrl': pub_url,
-                            },
-                        ],
-                    },
-                }).json()
-
+            response = client.post("/", json=publisher_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
             entity = response['data']['_entities'][0]
@@ -134,68 +140,47 @@ class TestGraphQLRelated(TestCase):
                                                              "b4cbf203-50cd-45fc-97c8-e1fddac2f270"}
 
     def test_related_end_of_article_article_doesnt_exist(self):
+        item_id = '11111'
+        pub_url = 'xxxx'
+
         with TestClient(app) as client:
-            response = client.post("/", json={
-                    'query': '''
-                        query ($representations: [_Any!]!) {
-                          _entities(representations: $representations) {
-                            ... on SyndicatedArticle {
-                                itemId
-                                publisherUrl
-                                relatedEndOfArticle(count: 3) {
-                                    id
-                                    corpusItem {
-                                      id
-                                    }
-                                }
-                            }
-                          }
-                        }
-                    ''',
-                    'variables': {
-                        'representations': [
-                            {
-                                '__typename': 'SyndicatedArticle',
-                                'itemId': "11111",
-                                'publisherUrl': "xxxxx",
-                            },
-                        ],
-                    },
-                }).json()
+            response = client.post("/", json=syndicated_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
-            recs = response['data']['_entities'][0]['relatedEndOfArticle']
-            assert len(recs) == 0
+            entity = response['data']['_entities'][0]
+            recs = entity['relatedEndOfArticle']
+            assert entity['itemId'] == item_id
+            assert entity['publisherUrl'] == pub_url
+            assert len(recs) == 3
+            assert 'id' in recs[0]
+            assert 'corpusItem' in recs[0]
+            assert 'id' in recs[0]['corpusItem']
+            assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_syndicated'] for r in recs)
 
     def test_related_right_rail_article_doesnt_exist(self):
+        item_id = '11111'
+        pub_url = 'https://psyche.co/ideas/are-successful-authors-creative-geniuses-or-literary-labourers'
+
         with TestClient(app) as client:
-            response = client.post("/", json={
-                'query': '''
-                        query ($representations: [_Any!]!) {
-                          _entities(representations: $representations) {
-                            ... on SyndicatedArticle {
-                                itemId
-                                publisherUrl
-                                relatedRightRail(count: 3) {
-                                    id
-                                    corpusItem {
-                                      id
-                                    }
-                                }
-                            }
-                          }
-                        }
-                    ''',
-                    'variables': {
-                        'representations': [
-                            {
-                                '__typename': 'SyndicatedArticle',
-                                'itemId': "111111",
-                                'publisherUrl': "xxxx",
-                            },
-                        ],
-                    },
-                }).json()
+            response = client.post("/", json=publisher_json(item_id, pub_url)).json()
+
+            assert not response.get('errors')
+            entity = response['data']['_entities'][0]
+            recs = entity['relatedRightRail']
+            assert entity['itemId'] == item_id
+            assert entity['publisherUrl'] == pub_url
+            assert len(recs) == 3
+            assert 'id' in recs[0]
+            assert 'corpusItem' in recs[0]
+            assert 'id' in recs[0]['corpusItem']
+            assert all(self.art_by_corpus_id[r['corpusItem']['id']]['domain'] == 'psyche.co' for r in recs)
+
+    def test_related_right_rail_article_and_publisher_dont_exist(self):
+        item_id = '11111'
+        pub_url = 'https://xxx.co/ideas/'
+
+        with TestClient(app) as client:
+            response = client.post("/", json=publisher_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
             recs = response['data']['_entities'][0]['relatedRightRail']


### PR DESCRIPTION
# Goal

There should always be some recommendations displayed, even if the article was just added to the corpus and vectors store is not updated yet. Fallback to random syndicated or publisher articles.

## Reference

Tickets:
* [Link to JIRA tickets](https://getpocket.atlassian.net/browse/TDP-108)

## Implementation Decisions
We could probably come up with something smarter for syndicated, like a filter by `save_count > 10000` but it will require adding another index on the pipeline side, so I don't want to overcomplicate it for now. Unfortunately, qdrant doesn' support ordering for the scroll method 