### PR TITLE
Standardize logging of related recs

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -59,7 +59,7 @@ class Item2ItemDispatch:
             recs = await self.item_recommender.related(resolved_id, count)
         except Item2ItemError:
             # fallback to frequently saved for "You Might Also Like"
-            recs = await self.item_recommender.frequently_saved(count=100)
+            recs = await self.item_recommender.frequently_saved_curated(count=100)
         return self._sample(recs, count)
 
     @_empty_on_error
@@ -68,7 +68,7 @@ class Item2ItemDispatch:
             recs = await self.item_recommender.syndicated(resolved_id, count)
         except Item2ItemError:
             # fallback to frequently saved syndicated for syndicated "More Stories from Pocket"
-            recs = await self.item_recommender.frequently_saved(count=100, is_syndicated=True)
+            recs = await self.item_recommender.frequently_saved_syndicated(count=100)
         return self._sample(recs, count)
 
     @_empty_on_error

--- a/tests/functional/graphql/test_related.py
+++ b/tests/functional/graphql/test_related.py
@@ -4,7 +4,9 @@ import os
 from time import sleep
 from unittest import TestCase, mock
 from unittest.mock import patch
+import re
 
+import pytest
 from fastapi.testclient import TestClient
 from qdrant_client.http.api.points_api import AsyncPointsApi
 from qdrant_client.http.exceptions import UnexpectedResponse
@@ -159,6 +161,8 @@ qdrant_error_mock = mock.Mock()
 qdrant_error_mock.side_effect = UnexpectedResponse(500, 'error', None, None)
 
 logging.getLogger().setLevel(logging.INFO)
+log_pattern = re.compile(
+    'Related: [\w ]+; method: \w+,( filter: [\'\[\] \w,]+,)?( resolved_id: \d+,)?( code: \d+,)?( reason: [\w ]+)?')
 
 
 class TestGraphQLRelated(TestCase):
@@ -166,6 +170,24 @@ class TestGraphQLRelated(TestCase):
     def setUpClass(cls):
         test_data = populate_qdrant()
         cls.art_by_corpus_id = {d['payload']['corpus_item_id']: d['payload'] for d in test_data}
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self.caplog = caplog
+
+    def verify_logs(self, level: int, resolved_id=None, msg=None, method=None):
+        related_logs = [rec for rec in self.caplog.records if 'Related:' in rec.message and level == rec.levelno]
+        assert related_logs
+        for rec in related_logs:
+            assert re.search(log_pattern, rec.msg)
+
+        last_rec = related_logs[-1].message
+        if resolved_id:
+            assert str(resolved_id) in last_rec
+        if msg:
+            assert msg in last_rec
+        if method:
+            assert f'method: {method}' in last_rec
 
     def test_related_after_save_basic(self):
         """ recommend similar curated """
@@ -183,6 +205,7 @@ class TestGraphQLRelated(TestCase):
             assert 'corpusItem' in recs[0]
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_curated'] for r in recs)
+            self.verify_logs(logging.INFO, item_id)
 
     def test_related_after_article(self):
         """ recommend similar curated """
@@ -200,6 +223,7 @@ class TestGraphQLRelated(TestCase):
             assert 'corpusItem' in recs[0]
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_curated'] for r in recs), recs
+            self.verify_logs(logging.INFO, item_id)
 
     def test_related_end_of_syndicated_basic(self):
         """ recommend similar syndicated """
@@ -219,6 +243,7 @@ class TestGraphQLRelated(TestCase):
             assert 'corpusItem' in recs[0]
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_syndicated'] for r in recs)
+            self.verify_logs(logging.INFO, item_id)
 
     def test_related_right_rail_basic(self):
         """ recommend similar curated from the same publisher """
@@ -239,6 +264,7 @@ class TestGraphQLRelated(TestCase):
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['domain'] == 'psyche.co' for r in recs)
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_curated'] for r in recs)
+            self.verify_logs(logging.INFO, item_id)
 
     def test_related_syndicated_article_doesnt_exist(self):
         """ fallback to random frequently saved syndicated """
@@ -259,6 +285,8 @@ class TestGraphQLRelated(TestCase):
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_syndicated'] for r in recs)
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['save_count'] > 1000 for r in recs)
+            self.verify_logs(logging.WARNING, item_id, msg='article not found')
+            self.verify_logs(logging.INFO, msg='scroll')
 
     def test_related_right_rail_article_doesnt_exist(self):
         """ fallback to random from the same publisher """
@@ -278,6 +306,8 @@ class TestGraphQLRelated(TestCase):
             assert 'corpusItem' in recs[0]
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['domain'] == 'psyche.co' for r in recs)
+            self.verify_logs(logging.WARNING, item_id, msg='article not found')
+            self.verify_logs(logging.INFO, msg='scroll')
 
     def test_related_right_rail_publisher_doesnt_exist(self):
         """ do not fallback, having the same publisher is a hard requirement """
@@ -293,6 +323,7 @@ class TestGraphQLRelated(TestCase):
             assert entity['itemId'] == item_id
             assert entity['publisherUrl'] == pub_url
             assert len(recs) == 0
+            self.verify_logs(logging.INFO, item_id)
 
     def test_related_right_rail_article_and_publisher_dont_exist(self):
         """ do not fallback, having the same publisher is a hard requirement """
@@ -305,6 +336,8 @@ class TestGraphQLRelated(TestCase):
             assert not response.get('errors')
             recs = response['data']['_entities'][0]['relatedRightRail']
             assert len(recs) == 0
+            self.verify_logs(logging.WARNING, item_id, msg='article not found')
+            self.verify_logs(logging.INFO, msg='scroll')
 
     def test_related_after_article_article_doesnt_exist(self):
         """ fallback to random frequently saved curated """
@@ -323,6 +356,8 @@ class TestGraphQLRelated(TestCase):
             assert 'id' in recs[0]['corpusItem']
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['is_curated'] for r in recs)
             assert all(self.art_by_corpus_id[r['corpusItem']['id']]['save_count'] > 1000 for r in recs)
+            self.verify_logs(logging.WARNING, item_id, msg='article not found')
+            self.verify_logs(logging.INFO, msg='scroll')
 
     def test_related_after_save_article_doesnt_exist(self):
         """ do not fallback """
@@ -336,6 +371,8 @@ class TestGraphQLRelated(TestCase):
             recs = entity['relatedAfterCreate']
             assert entity['itemId'] == item_id
             assert len(recs) == 0
+            self.verify_logs(logging.WARNING, item_id, msg='article not found')
+            self.verify_logs(logging.INFO, item_id, msg='recommend')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)
@@ -347,6 +384,7 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedAfterCreate']) == 0
+            self.verify_logs(logging.ERROR, msg='unexpected response')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)
@@ -358,6 +396,7 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedAfterArticle']) == 0
+            self.verify_logs(logging.ERROR, msg='unexpected response')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)
@@ -370,6 +409,7 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedEndOfArticle']) == 0
+            self.verify_logs(logging.ERROR, msg='unexpected response')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)
@@ -382,6 +422,7 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedRightRail']) == 0
+            self.verify_logs(logging.ERROR, msg='unexpected response')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     def test_related_after_article_fallback_cached(self):
@@ -392,12 +433,14 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedAfterArticle']) == 3
+            self.verify_logs(logging.INFO, method='scroll')
 
             with patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock):
                 response = client.post("/", json=after_article_json(item_id)).json()
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedAfterArticle']) == 3
+            self.verify_logs(logging.INFO, method='cache', msg='curated')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     def test_related_end_of_syndicated_fallback_cached(self):
@@ -409,12 +452,14 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedEndOfArticle']) == 3
+            self.verify_logs(logging.INFO, msg='scroll')
 
             with patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock):
                 response = client.post("/", json=syndicated_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedEndOfArticle']) == 3
+            self.verify_logs(logging.INFO, method='cache', msg='syndicated')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     def test_related_right_rail_fallback_cached(self):
@@ -426,9 +471,12 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedRightRail']) == 3
+            self.verify_logs(logging.INFO, msg='scroll')
 
             with patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock):
                 response = client.post("/", json=publisher_json(item_id, pub_url)).json()
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedRightRail']) == 3
+            self.verify_logs(logging.INFO, method='cache', msg='publisher')
+

--- a/tests/functional/graphql/test_related.py
+++ b/tests/functional/graphql/test_related.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from time import sleep
 from unittest import TestCase, mock
@@ -156,6 +157,8 @@ def after_save_json(item_id: str):
 
 qdrant_error_mock = mock.Mock()
 qdrant_error_mock.side_effect = UnexpectedResponse(500, 'error', None, None)
+
+logging.getLogger().setLevel(logging.INFO)
 
 
 class TestGraphQLRelated(TestCase):


### PR DESCRIPTION
# Goal

Add custom monitoring of how many errors and fallbacks we have in new related recommendations.

## Reference

Tickets:
* [Link to JIRA tickets](https://getpocket.atlassian.net/browse/TDP-123)

## Implementation Decisions

I'm going to use logging parsing like it was done in Recit as the simplest solution. 
The proper approach of course would be to implement either [ structured logging](https://docs.aws.amazon.com/lambda/latest/operatorguide/parse-logs.html) or use a dedicated library for reporting custom application metrics.
