### PR TITLE
fix(Home): All users who prefer German should receive German Home [TDP-270]

### DIFF
--- a/app/models/localemodel.py
+++ b/app/models/localemodel.py
@@ -16,9 +16,14 @@ class LocaleModel(Enum):
     de_DE = LocaleValue('de-DE')
 
     @classmethod
-    def from_string(cls, val: str, default: en_US) -> 'LocaleModel':
+    def from_string(cls, val: str, default: 'LocaleModel' = None) -> 'LocaleModel':
         for locale in cls:
             if locale.value.lower() == val.lower():
+                return locale
+
+        language = val.split('-')[0].lower()
+        for locale in cls:
+            if locale.value.startswith(language):
                 return locale
 
         return default

--- a/tests/unit/models/test_locale_model.py
+++ b/tests/unit/models/test_locale_model.py
@@ -1,0 +1,25 @@
+from app.models.localemodel import LocaleModel
+
+
+def test_from_string_full_locale():
+    assert LocaleModel.en_US == LocaleModel.from_string('en-US')
+    assert LocaleModel.en_US == LocaleModel.from_string('en-us')
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-DE')
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-de')
+
+
+def test_from_string_language_match():
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-AT')
+    assert LocaleModel.en_US == LocaleModel.from_string('en-CA')
+
+
+def test_from_string_language_only():
+    assert LocaleModel.en_US == LocaleModel.from_string('en')
+    assert LocaleModel.en_US == LocaleModel.from_string('EN')
+    assert LocaleModel.de_DE == LocaleModel.from_string('de')
+    assert LocaleModel.de_DE == LocaleModel.from_string('DE')
+
+
+def test_from_string_default():
+    assert LocaleModel.from_string('xx-YY') is None
+    assert LocaleModel.en_US == LocaleModel.from_string('xx-YY', LocaleModel.en_US)


### PR DESCRIPTION
# Goal
All users who prefer the German language should receive German Home, including locales such as `de-AT` (Austria).

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/TDP-270

## Implementation Decisions
- [corpus_slate_lineup_resolvers.py](https://github.com/Pocket/recommendation-api/blob/main/app/graphql/resolvers/corpus_slate_lineup_resolvers.py#L34) sets the default using `LocaleModel.from_string(locale, default=LocaleModel.en_US)`. `LocaleModel.from_string` now returns None if the `default` argument is not provided and the locale cannot be matched.