### PR TITLE
fix(Home): German link for more collections is broken [DIS-164]

### DIFF
--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -20,14 +20,9 @@ class CollectionSlateProvider(SlateProvider):
 
     @property
     def more_link(self) -> Optional[LinkModel]:
-        base_url = 'https://getpocket.com'
-
-        if self.locale == LocaleModel.en_US:
-            url = f'{base_url}/collections'
-        else:
-            url = f'{base_url}/{self.locale.value.language}/collections'
-
-        return LinkModel(text=self.home_translations['CollectionsSlateProvider.more_link_text'], url=url)
+        return LinkModel(
+            text=self.home_translations['CollectionsSlateProvider.more_link_text'],
+            url='https://getpocket.com/collections')
 
     async def rank_corpus_items(
             self,

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -256,6 +256,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
             assert slates[0]['headline'] == 'Empfohlene Artikel'
             assert slates[0]['subheadline'] == 'Von Pocket kuratiert'
             assert slates[1]['headline'] == 'Beliebte Collections'
+            assert slates[1]['moreLink']['url'] == 'https://getpocket.com/collections'
             assert slates[1]['moreLink']['text'] == 'Mehr Collections entdecken'
             assert slates[-1]['headline'] == 'Für ein glücklicheres Ich'
             assert slates[-1]['moreLink'] == None


### PR DESCRIPTION
# Goal
Fix broken link to explore more German Collections.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-164

## Implementation Decisions
- Joel prefers to link to /collections and let the client redirect to the appropriate locale. I don't have a strong opinion either way, but the less client-specific logic that Recommendation API has to implement, the better. We might have to revisit this as new requirements come up when expanding to different markets.