### PR TITLE
Handle more qdrant calling exceptions

### DIFF
--- a/app/data_providers/item2item.py
+++ b/app/data_providers/item2item.py
@@ -145,6 +145,10 @@ class Item2ItemRecommender:
                 _log(logging.ERROR, 'unexpected response', 'recommend', resolved_id=resolved_id,
                      filter=query_filter, code=ex.status_code, reason=ex.reason_phrase)
                 raise QdrantError()
+        except Exception as ex:
+            _log(logging.ERROR, 'Qdrant error', 'recommend', resolved_id=resolved_id,
+                 filter=query_filter, reason=str(ex))
+            raise QdrantError()
 
         return [CorpusItemModel(id=rec.payload['corpus_item_id'], topic=rec.payload['topic'])
                 for rec in res]
@@ -163,6 +167,10 @@ class Item2ItemRecommender:
         except UnexpectedResponse as ex:
             _log(logging.ERROR, 'unexpected response', 'scroll',
                  filter=query_filter, code=ex.status_code, reason=ex.reason_phrase)
+            raise QdrantError()
+        except Exception as ex:
+            _log(logging.ERROR, 'Qdrant error', 'scroll',
+                 filter=query_filter, reason=str(ex))
             raise QdrantError()
 
         return [CorpusItemModel(id=rec.payload['corpus_item_id'], topic=rec.payload['topic'])

--- a/tests/functional/graphql/test_related.py
+++ b/tests/functional/graphql/test_related.py
@@ -159,6 +159,8 @@ def after_save_json(item_id: str):
 
 qdrant_error_mock = mock.Mock()
 qdrant_error_mock.side_effect = UnexpectedResponse(500, 'error', None, None)
+qdrant_unexpected_error_mock = mock.Mock()
+qdrant_unexpected_error_mock.side_effect = ValueError('something went wrong')
 log_pattern = re.compile(
     'Related: [\w ]+; method: \w+,( filter: [\'\[\] \w,]+,)?( resolved_id: \d+,)?( code: \d+,)?( reason: [\w ]+)?')
 
@@ -384,8 +386,8 @@ class TestGraphQLRelated(TestCase):
             assert len(response['data']['_entities'][0]['relatedAfterCreate']) == 0
             self.verify_logs(logging.ERROR, msg='unexpected response')
 
-    @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
-    @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)
+    @patch.object(AsyncPointsApi, 'recommend_points', qdrant_unexpected_error_mock)
+    @patch.object(AsyncPointsApi, 'scroll_points', qdrant_unexpected_error_mock)
     def test_related_after_article_qdrant_outage(self):
         item_id = '3727699409'
 
@@ -394,7 +396,7 @@ class TestGraphQLRelated(TestCase):
 
             assert not response.get('errors')
             assert len(response['data']['_entities'][0]['relatedAfterArticle']) == 0
-            self.verify_logs(logging.ERROR, msg='unexpected response')
+            self.verify_logs(logging.ERROR, msg='Qdrant error')
 
     @patch.object(AsyncPointsApi, 'recommend_points', qdrant_error_mock)
     @patch.object(AsyncPointsApi, 'scroll_points', qdrant_error_mock)


### PR DESCRIPTION
# Goal

Make sure all qdrant exceptions are always handled. Otherwise, it breaks the whole syndicated page.
