### PR TITLE
Add graphql caching for related

### DIFF
--- a/app/graphql/directives.py
+++ b/app/graphql/directives.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+import strawberry
+from strawberry import schema_directive
+from strawberry.schema_directive import Location
+
+
+@strawberry.enum()
+class CacheControlScope(Enum):
+    PUBLIC = strawberry.enum_value('PUBLIC')
+    PRIVATE = strawberry.enum_value('PRIVATE')
+
+
+@schema_directive(
+    locations=[
+        Location.FIELD_DEFINITION,
+        Location.INTERFACE,
+        Location.OBJECT
+    ],
+    name="cacheControl",
+    print_definition=True,
+)
+class CacheControl:
+    maxAge: int
+    scope: CacheControlScope = CacheControlScope.PUBLIC

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -4,6 +4,7 @@ import strawberry
 from strawberry.federation.schema_directives import Key
 
 from app.graphql.corpus_recommendation import CorpusRecommendation
+from app.graphql.directives import CacheControl
 from app.graphql.resolvers.item2item_resolvers import resolve_similar_to_saved, resolve_after_article
 from app.models.item import ItemModel
 
@@ -15,9 +16,11 @@ class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
 
     relatedAfterArticle: List[CorpusRecommendation] = strawberry.field(
+        directives=[CacheControl(maxAge=3600)],
         resolver=resolve_after_article,
         description='Recommend similar articles to show in the bottom of an article.')
 
     relatedAfterCreate: List[CorpusRecommendation] = strawberry.field(
+        directives=[CacheControl(maxAge=3600)],
         resolver=resolve_similar_to_saved,
         description='Recommend similar articles after saving.')

--- a/app/graphql/syndicated_article.py
+++ b/app/graphql/syndicated_article.py
@@ -3,6 +3,7 @@ from typing import List
 import strawberry
 
 from app.graphql.corpus_recommendation import CorpusRecommendation
+from app.graphql.directives import CacheControl
 from app.graphql.resolvers.item2item_resolvers import resolve_syndicated_end_of_article, resolve_syndicated_right_rail
 
 
@@ -13,9 +14,11 @@ class SyndicatedArticle:
     originalItemId: strawberry.ID
 
     relatedEndOfArticle: List[CorpusRecommendation] = strawberry.field(
+        directives=[CacheControl(maxAge=3600)],
         resolver=resolve_syndicated_end_of_article,
         description='Recommend similar syndicated articles.')
     relatedRightRail: List[CorpusRecommendation] = strawberry.field(
+        directives=[CacheControl(maxAge=3600)],
         resolver=resolve_syndicated_right_rail,
         description='Recommend similar articles from the same publisher.')
 


### PR DESCRIPTION
# Goal

Move related recs caching to Apollo. Currently, not critical, but this will help to reduce the load on recAPI and vector store when firefox on-save and Android reader migration will be released.

I'm assuming here it will be cached on the Apollo server side. I don't completely understand how the whole thing works, so I might be wrong. I'll disable in-memory caching later if it works.

[Apollo docs](https://www.apollographql.com/docs/apollo-server/performance/caching/#using-with-federation)

[jira ticket](https://getpocket.atlassian.net/browse/TDP-304)