### PR TITLE
Return empty recs for unsupported language

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -7,7 +7,7 @@ from aws_xray_sdk.core import xray_recorder
 
 from app.config import DEFAULT_TOPICS, GERMAN_HOME_TOPICS
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
-from app.data_providers.item2item import Item2ItemRecommender, Item2ItemError, QdrantError
+from app.data_providers.item2item import Item2ItemRecommender, Item2ItemError, QdrantError, UnsupportedLanguage
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
 from app.data_providers.slate_providers.for_you_slate_provider import ForYouSlateProvider
 from app.data_providers.slate_providers.life_hacks_slate_provider import LifeHacksSlateProvider
@@ -43,19 +43,28 @@ class Item2ItemDispatch:
     def __init__(self, item_recommender: Item2ItemRecommender):
         self.item_recommender = item_recommender
 
-    async def after_save(self, resolved_id: int, count: int) -> List[CorpusRecommendationModel]:
+    async def after_save(self,
+                         resolved_id: int,
+                         lang: str,
+                         count: int) -> List[CorpusRecommendationModel]:
         try:
-            recs = await self.item_recommender.related(resolved_id, count)
+            recs = await self.item_recommender.related(resolved_id, count, lang)
         except Item2ItemError:
-            # do not fallback for "Similar stores" after saving
+            # do not fallback for "Similar stories" after saving
             recs = []
         return self._to_corpus_items(recs, count)
 
     @_empty_on_error
-    async def after_article(self, resolved_id: int, count: int) -> List[CorpusRecommendationModel]:
+    async def after_article(self,
+                            resolved_id: int,
+                            lang: str,
+                            count: int) -> List[CorpusRecommendationModel]:
         try:
             # request more to apply domain diversification
-            recs = await self.item_recommender.related(resolved_id, 20)
+            recs = await self.item_recommender.related(resolved_id, count=20, lang=lang)
+        except UnsupportedLanguage:
+            # do not fallback for unsupported language
+            return []
         except Item2ItemError:
             # fallback to frequently saved for "You Might Also Like"
             recs = await self.item_recommender.frequently_saved_curated(count=100)

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -11,7 +11,7 @@ from app.models.item import ItemModel
 
 @strawberry.experimental.pydantic.type(
     model=ItemModel,
-    directives=[Key(fields="itemId", resolvable=False)])
+    directives=[Key(fields="itemId")])
 class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
 

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 import strawberry
-from strawberry.federation.schema_directives import Key
+from strawberry.federation.schema_directives import Key, Requires
 
 from app.graphql.corpus_recommendation import CorpusRecommendation
 from app.graphql.directives import CacheControl
@@ -11,17 +11,22 @@ from app.models.item import ItemModel
 
 @strawberry.experimental.pydantic.type(
     model=ItemModel,
-    directives=[Key(fields="itemId language", resolvable=False)])
+    directives=[Key(fields="itemId", resolvable=False)])
 class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
-    language: Optional[str]
+
+    # a field from a different subgraph
+    # see https://www.apollographql.com/docs/federation/entities-advanced/#contributing-computed-entity-fields
+    language: Optional[str] = strawberry.federation.field(external=True)
 
     relatedAfterArticle: List[CorpusRecommendation] = strawberry.field(
-        directives=[CacheControl(maxAge=3600)],
+        directives=[CacheControl(maxAge=3600),
+                    Requires(fields='language')],
         resolver=resolve_after_article,
         description='Recommend similar articles to show in the bottom of an article.')
 
     relatedAfterCreate: List[CorpusRecommendation] = strawberry.field(
-        directives=[CacheControl(maxAge=3600)],
+        directives=[CacheControl(maxAge=3600),
+                    Requires(fields='language')],
         resolver=resolve_similar_to_saved,
         description='Recommend similar articles after saving.')

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -11,9 +11,10 @@ from app.models.item import ItemModel
 
 @strawberry.experimental.pydantic.type(
     model=ItemModel,
-    directives=[Key(fields="itemId")])
+    directives=[Key(fields="itemId language")])
 class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
+    language: str
 
     relatedAfterArticle: List[CorpusRecommendation] = strawberry.field(
         directives=[CacheControl(maxAge=3600)],

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import strawberry
 from strawberry.federation.schema_directives import Key
@@ -14,7 +14,7 @@ from app.models.item import ItemModel
     directives=[Key(fields="itemId language")])
 class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
-    language: str
+    language: Optional[str]
 
     relatedAfterArticle: List[CorpusRecommendation] = strawberry.field(
         directives=[CacheControl(maxAge=3600)],

--- a/app/graphql/item.py
+++ b/app/graphql/item.py
@@ -11,7 +11,7 @@ from app.models.item import ItemModel
 
 @strawberry.experimental.pydantic.type(
     model=ItemModel,
-    directives=[Key(fields="itemId language")])
+    directives=[Key(fields="itemId language", resolvable=False)])
 class Item:
     item_id: str  # This type is a 'str' and not an 'ID' in our graph.
     language: Optional[str]

--- a/app/graphql/resolvers/item2item_resolvers.py
+++ b/app/graphql/resolvers/item2item_resolvers.py
@@ -20,7 +20,10 @@ async def resolve_similar_to_saved(
         = DEFAULT_RECOMMENDATION_COUNT,
 ) -> List[CorpusRecommendation]:
     dispatch = Item2ItemDispatch(item_recommender=DiContainer.get().item2item_recommender)
-    recs = await dispatch.after_save(resolved_id=int(root.item_id), count=count)
+    lang = root.language.lower()[:2] if root.language else 'en'
+    recs = await dispatch.after_save(resolved_id=int(root.item_id),
+                                     lang=lang,
+                                     count=count)
     return [CorpusRecommendation.from_pydantic(rec) for rec in recs]
 
 
@@ -32,7 +35,10 @@ async def resolve_after_article(
         = DEFAULT_RECOMMENDATION_COUNT,
 ) -> List[CorpusRecommendation]:
     dispatch = Item2ItemDispatch(item_recommender=DiContainer.get().item2item_recommender)
-    recs = await dispatch.after_article(resolved_id=int(root.item_id), count=count)
+    lang = root.language.lower()[:2] if root.language else 'en'
+    recs = await dispatch.after_article(resolved_id=int(root.item_id),
+                                        lang=lang,
+                                        count=count)
     return [CorpusRecommendation.from_pydantic(rec) for rec in recs]
 
 

--- a/app/graphql/syndicated_article.py
+++ b/app/graphql/syndicated_article.py
@@ -1,29 +1,32 @@
 from typing import List
 
 import strawberry
-from strawberry.federation.schema_directives import Requires
 
 from app.graphql.corpus_recommendation import CorpusRecommendation
 from app.graphql.directives import CacheControl
 from app.graphql.resolvers.item2item_resolvers import resolve_syndicated_end_of_article, resolve_syndicated_right_rail
 
 
-@strawberry.federation.type(keys=["itemId"])
+@strawberry.federation.type(keys=["itemId publisherUrl originalItemId"])
 class SyndicatedArticle:
     itemId: strawberry.ID  # this corresponds to Snowflake resolved_id
-
-    # these fields are from a different subgraph
-    # see https://www.apollographql.com/docs/federation/entities-advanced/#contributing-computed-entity-fields
-    publisherUrl: str = strawberry.federation.field(external=True)
-    originalItemId: strawberry.ID = strawberry.federation.field(external=True)
+    publisherUrl: str
+    originalItemId: strawberry.ID
 
     relatedEndOfArticle: List[CorpusRecommendation] = strawberry.field(
         directives=[CacheControl(maxAge=3600)],
         resolver=resolve_syndicated_end_of_article,
         description='Recommend similar syndicated articles.')
     relatedRightRail: List[CorpusRecommendation] = strawberry.field(
-        directives=[CacheControl(maxAge=3600),
-                    Requires(fields='publisherUrl originalItemId')],
+        directives=[CacheControl(maxAge=3600)],
         resolver=resolve_syndicated_right_rail,
         description='Recommend similar articles from the same publisher.')
 
+    @classmethod
+    def resolve_reference(cls,
+                          itemId: strawberry.ID,
+                          publisherUrl: str,
+                          originalItemId: strawberry.ID):
+        return SyndicatedArticle(itemId=itemId,
+                                 publisherUrl=publisherUrl,
+                                 originalItemId=originalItemId)

--- a/app/graphql/syndicated_article.py
+++ b/app/graphql/syndicated_article.py
@@ -1,32 +1,29 @@
 from typing import List
 
 import strawberry
+from strawberry.federation.schema_directives import Requires
 
 from app.graphql.corpus_recommendation import CorpusRecommendation
 from app.graphql.directives import CacheControl
 from app.graphql.resolvers.item2item_resolvers import resolve_syndicated_end_of_article, resolve_syndicated_right_rail
 
 
-@strawberry.federation.type(keys=["itemId publisherUrl originalItemId"])
+@strawberry.federation.type(keys=["itemId"])
 class SyndicatedArticle:
     itemId: strawberry.ID  # this corresponds to Snowflake resolved_id
-    publisherUrl: str
-    originalItemId: strawberry.ID
+
+    # these fields are from a different subgraph
+    # see https://www.apollographql.com/docs/federation/entities-advanced/#contributing-computed-entity-fields
+    publisherUrl: str = strawberry.federation.field(external=True)
+    originalItemId: strawberry.ID = strawberry.federation.field(external=True)
 
     relatedEndOfArticle: List[CorpusRecommendation] = strawberry.field(
         directives=[CacheControl(maxAge=3600)],
         resolver=resolve_syndicated_end_of_article,
         description='Recommend similar syndicated articles.')
     relatedRightRail: List[CorpusRecommendation] = strawberry.field(
-        directives=[CacheControl(maxAge=3600)],
+        directives=[CacheControl(maxAge=3600),
+                    Requires(fields='publisherUrl originalItemId')],
         resolver=resolve_syndicated_right_rail,
         description='Recommend similar articles from the same publisher.')
 
-    @classmethod
-    def resolve_reference(cls,
-                          itemId: strawberry.ID,
-                          publisherUrl: str,
-                          originalItemId: strawberry.ID):
-        return SyndicatedArticle(itemId=itemId,
-                                 publisherUrl=publisherUrl,
-                                 originalItemId=originalItemId)


### PR DESCRIPTION
# Goal

Fix a bug when related recommendations are displayed for a non-English item

## Jira

[ticket](https://getpocket.atlassian.net/browse/TDP-327)

## Implementation Decisions

@mmiermans @bassrock Will apollo provide `language` field to recAPI as a part of federated key if it is not present in the client request? I assume yes.
[edit]: it seems apollo is unhappy with this. any ideas on how to work around and pull language?

@anthony-liddle FYI