### PR TITLE
Split qdrant collection

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -61,7 +61,7 @@ qdrant = {
    'host': os.getenv('QDRANT_HOST', 'qdrant.readitlater.com'),
    'port': os.getenv('QDRANT_PORT', 443),
    'https': os.getenv('QDRANT_HTTPS', 'true') == 'true',
-   'collection': os.getenv('QDRANT_COLLECTION', 'articlesprod_v2')
+   'collection': os.getenv('QDRANT_COLLECTION', 'articlesprod_v3')
 }
 
 

--- a/app/data_providers/item2item.py
+++ b/app/data_providers/item2item.py
@@ -64,7 +64,9 @@ class Item2ItemRecommender:
         host = app.config.qdrant["host"]
         port = app.config.qdrant["port"]
         https = app.config.qdrant["https"]
+        # recommendations corpus
         self.recs_collection = app.config.qdrant["collection"] + '_recs'
+        # all available items for lookup
         self.all_collection = app.config.qdrant["collection"] + '_all'
         self._client = AsyncApis(host=f"http{'s' if https else ''}://{host}:{port}").points_api
 


### PR DESCRIPTION
# Goal

Split the Qdrant collection into two: all items and recommendation items with metadata.
This helps with the following:
- Search accuracy because ANN will work on 40k items instead of 1.5M
- Search performance (significantly fewer items to index)
- Easier deletion of outdated items

Related changes in the metaflow pipeline: https://github.com/Pocket/dl-metaflow-jobs/pull/174

## Reference

Tickets:
- [Bug](https://getpocket.atlassian.net/browse/DIS-323)
- [Task](https://getpocket.atlassian.net/browse/DIS-398)
