### PR TITLE
Remove qdrant topic usage

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -98,7 +98,7 @@ class Item2ItemDispatch:
 
     @staticmethod
     def _to_corpus_items(recs, count):
-        return [CorpusRecommendationModel(corpus_item=CorpusItemModel(id=r.corpus_item_id, topic=r.topic))
+        return [CorpusRecommendationModel(corpus_item=CorpusItemModel(id=r.corpus_item_id, topic=None))
                 for r in recs[:count]]
 
 

--- a/app/data_providers/item2item.py
+++ b/app/data_providers/item2item.py
@@ -217,6 +217,5 @@ class Item2ItemRecommender:
     def _convert_response(res):
         logging.debug(f'Related: {res}')
         return [RelatedItem(corpus_item_id=rec.payload['corpus_item_id'],
-                            domain=rec.payload['domain'],
-                            topic=rec.payload['topic'])
+                            domain=rec.payload['domain'])
                 for rec in res]


### PR DESCRIPTION
# Goal

Fix syndicated page failure. Topic is optional for corpus items.
