### PR TITLE
fix(NewTab): Argument descriptions were grabled

### DIFF
--- a/app/graphql/resolvers/corpus_slate_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_resolvers.py
@@ -1,7 +1,8 @@
-from typing import Optional, Annotated
+from typing import Optional
 
 import strawberry
 from strawberry.types import Info
+from typing_extensions import Annotated
 
 from app.data_providers.dispatch import NewTabDispatch
 from app.data_providers.slate_providers.new_tab_slate_provider import NewTabSlateProvider

--- a/app/graphql/resolvers/corpus_slate_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_resolvers.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Annotated
 
 import strawberry
 from strawberry.types import Info
@@ -14,13 +14,13 @@ from app.singletons import DiContainer
 async def resolve_new_tab_slate(
         root,
         info: Info,
-        locale: str = strawberry.argument(
+        locale: Annotated[str, strawberry.argument(
             description="The Firefox build locale, for example 'fr-FR' or 'fr'. This determines which scheduled surface"
-                        " will be returned."),
-        region: Optional[str] = strawberry.argument(
+                        " will be returned.")],
+        region: Annotated[Optional[str], strawberry.argument(
             description="The geographic region, for example 'FR' or 'IT', or null if unavailable. This is currently not"
                         " used, but will be used in the future to decide which scheduled surface to return when we"
-                        " serve multiple markets with the same language."),
+                        " serve multiple markets with the same language.")],
 ) -> CorpusSlate:
     di = DiContainer.get()
     locale_model = LocaleModel.from_string(locale, default=LocaleModel.en_US)

--- a/app/models/corpus_recommendation_model.py
+++ b/app/models/corpus_recommendation_model.py
@@ -18,7 +18,7 @@ class CorpusRecommendationModel(BaseModel):
     tile_id: float = Field(
         default=0,  # This value should be provided when constructing CorpusRecommendationModel for Firefox New Tab.
         description='Firefox clients require an integer id. Other clients should use `id` instead of this field. '
-                    'tileId uniquely identifies the ScheduledSurface, CorpusItem, and scheduled_date.'
+                    'tileId uniquely identifies the ScheduledSurface, CorpusItem, and scheduled_date. '
                     'tileId is greater than 0 and less than 2^53 to fit in a Javascript number (64-bit IEEE 754 float).'
                     ' The field type is a Float because a GraphQL Int is limited to 32 bit.')
 

--- a/tests/functional/graphql/test_new_tab_slate.py
+++ b/tests/functional/graphql/test_new_tab_slate.py
@@ -22,7 +22,7 @@ def _corpus_items_fixture(n: int) -> [CorpusItemModel]:
 def _format_new_tab_query(locale, region, count=50):
     return '''
         query {
-          newTabSlate(locale: "%(locale)s") {
+          newTabSlate(locale: "%(locale)s", region: "%(region)s") {
             recommendations(count: %(count)d) {
               tileId
               corpusItem {


### PR DESCRIPTION
# Goal
- Fix garbled argument descriptions in the GraphQL schema for newTabSlate.
- Fix error in tests. `region` should be provided, but can be null.

Before:
```graphql
  newTabSlate(locale: String! = "<strawberry.arguments.StrawberryArgumentAnnotation object at 0x7f2bca05be50>", region: String = "<strawberry.arguments.StrawberryArgumentAnnotation object at 0x7f2bd96bb040>"): CorpusSlate!
```

After:
```graphql
  newTabSlate(
    """
    The Firefox build locale, for example 'fr-FR' or 'fr'. This determines which scheduled surface will be returned.
    """
    locale: String!

    """
    The geographic region, for example 'FR' or 'IT', or null if unavailable. This is currently not used, but will be used in the future to decide which scheduled surface to return when we serve multiple markets with the same language.
    """
    region: String
  ): CorpusSlate!
```