### PR TITLE
fix(FeatureGroupClient): BatchGetRecord limit

### DIFF
--- a/app/data_providers/feature_group/feature_group_client.py
+++ b/app/data_providers/feature_group/feature_group_client.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Optional
 
 from app.data_providers.util import chunks
 
-_BATCH_GET_RECORD_MAX_ITEMS = 10  # Maximum number of identifies that a Feature Store BatchGetRecord request supports.
+_BATCH_GET_RECORD_MAX_ITEMS = 100  # Maximum number of identifies that a Feature Store BatchGetRecord request supports.
 
 
 class FeatureGroupClient:


### PR DESCRIPTION
# Goal
Allow BatchGetRecord to fetch 100 records in a request, which should improve performance. The Sagemaker Developer Guide clearly states that this limit is 100:

> BatchGetRecord API: Can contain as many as 100 records and can query up to 10 feature groups.

What had me confused before is that the [BatchGetRecord API documentation](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_feature_store_BatchGetRecord.html) says that the Identifier argument can have a "Minimum number of 1 item. Maximum number of 10 items." However, an "item" in this context is a [BatchGetRecordIdentifier](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_feature_store_BatchGetRecordIdentifier.html) object that can take an array of 100 record identifiers.