### PR TITLE
fix(Snowplow): Error when apiId header is missing

### DIFF
--- a/app/models/api_client.py
+++ b/app/models/api_client.py
@@ -7,7 +7,7 @@ class ApiClient(BaseModel):
     """
 
     consumer_key: str = None
-    api_id: str = None
+    api_id: str
     application_name: str = None
     is_native: bool = None  # Indicates whether an app is a native Pocket app.
     is_trusted: bool = None  # Indicates the app is non-automated actions and represents real human usage


### PR DESCRIPTION
# Goal
Prevent [an error](https://pocket.sentry.io/issues/4059757046/events/9466644d8d9e4a6ca9c0e77d42b71174/?environment=production&project=5503693&query=is%3Aunresolved&referrer=previous-event&stream_index=0) being logged when the synthetic API monitor makes a request without an `apiId`:

![Screenshot from 2023-04-03 19-41-37](https://user-images.githubusercontent.com/1547251/229672968-d9f15bf2-0834-407d-ade2-813f8d14f35e.png)

# Implementation decisions
- The Snowplow tracker [checks that the api_client is truthy](https://github.com/Pocket/recommendation-api/blob/main/app/data_providers/snowplow/snowplow_corpus_recommendations_tracker.py#L65) before creating the Snowplow entity, so setting it to None will prevent the above error from being triggered.
- My initial thought was to put a check in the tracker `if event.api_client and event.api_client.api_id:` to avoid adding invalid data. Adding it to the Pydantic model seemed a better place, but I don't feel strongly.