### PR TITLE
feat(NewTab): Add Thompson sampling [DIS-456]

### DIFF
--- a/app/data_providers/feature_group/feature_group_client.py
+++ b/app/data_providers/feature_group/feature_group_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import aioboto3
 from typing import List, Dict, Optional
@@ -42,8 +43,14 @@ class FeatureGroupClient:
 
         result = []
         for record_set in record_sets:
-            for record in record_set['Records']:
+            records = record_set['Records']
+            for record in records:
                 result.append(self._record_to_dict(record['Record']))
+
+            errors = record_set.get('Errors')
+            if errors:
+                logging.error(f'batch_get_record received {len(records)} records and {len(errors)} errors. '
+                              f'First error: {errors[0]}')
 
         return result
 

--- a/tests/functional/graphql/test_new_tab_slate.py
+++ b/tests/functional/graphql/test_new_tab_slate.py
@@ -51,9 +51,11 @@ class TestNewTabSlate(TestDynamoDBBase):
         self.snowplow_micro.reset_snowplow_events()
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
+    @patch.object(FeatureGroupClient, 'batch_get_records')
     async def test_new_tab_slate_italy(
             self,
-            mock_fetch_corpus_items
+            mock_batch_get_records,
+            mock_fetch_corpus_items,
     ):
         corpus_items_fixture = _corpus_items_fixture(n=100)
         mock_fetch_corpus_items.return_value = corpus_items_fixture

--- a/tests/functional/graphql/test_new_tab_slate.py
+++ b/tests/functional/graphql/test_new_tab_slate.py
@@ -6,7 +6,6 @@ from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
 
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
-from app.data_providers.feature_group.feature_group_client import FeatureGroupClient
 from app.data_providers.slate_providers.new_tab_slate_provider import MIN_TILE_ID, MAX_TILE_ID
 from app.data_providers.snowplow.config import SnowplowConfig
 from app.main import app
@@ -51,12 +50,14 @@ class TestNewTabSlate(TestDynamoDBBase):
         self.snowplow_micro.reset_snowplow_events()
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
-    @patch.object(FeatureGroupClient, 'batch_get_records')
     async def test_new_tab_slate_italy(
             self,
-            mock_batch_get_records,
             mock_fetch_corpus_items,
     ):
+        """
+        FeatureGroupClient.batch_get_records is not patched in this test, so no engagement will be available for
+         Thompson sampling. The query should succeed even when access to the feature group is denied.
+        """
         corpus_items_fixture = _corpus_items_fixture(n=100)
         mock_fetch_corpus_items.return_value = corpus_items_fixture
 

--- a/tests/functional/test_util/caching.py
+++ b/tests/functional/test_util/caching.py
@@ -4,6 +4,7 @@ from aiocache import caches
 from app.cache import initialize_caches, candidate_set_alias, metrics_alias
 from app import config
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
+from app.data_providers.feature_group.corpus_engagement_provider import CorpusEngagementProvider
 from app.data_providers.topic_provider import TopicProvider
 
 
@@ -38,6 +39,7 @@ async def clear_function_caches():
     cached_functions = [
         TopicProvider._scan_table,
         CorpusFeatureGroupClient._query_corpus_items,
+        CorpusEngagementProvider._get_engagement_by_keys,
     ]
 
     for f in cached_functions:

--- a/tests/mocks/caching.py
+++ b/tests/mocks/caching.py
@@ -4,10 +4,16 @@ import pytest
 
 from aiocache import caches
 
-from tests.functional.test_util.caching import reset_caches
+from tests.functional.test_util.caching import reset_caches, clear_function_caches
 
 
 @pytest.fixture
 def aiocache_fixture():
     asyncio.run(reset_caches())
+    return caches
+
+
+@pytest.fixture
+def aiocache_functions_fixture():
+    asyncio.run(clear_function_caches())
     return caches

--- a/tests/mocks/corpus_engagement_provider.py
+++ b/tests/mocks/corpus_engagement_provider.py
@@ -10,7 +10,7 @@ from tests.mocks.feature_store_mock import FeatureStoreMock
 
 
 @pytest.fixture
-def corpus_engagement_provider(corpus_feature_group_client):
+def corpus_engagement_provider():
     feature_store_mock = FeatureStoreMock(
         feature_group_name=f'{config.ENV}-corpus-engagement-v1',
         records_json_path=os.path.join(ROOT_DIR, 'tests/assets/json/empty_feature_group.json')
@@ -18,4 +18,11 @@ def corpus_engagement_provider(corpus_feature_group_client):
 
     feature_group_client = FeatureGroupClient(aioboto3_session=feature_store_mock.aioboto3)
 
+    return CorpusEngagementProvider(feature_group_client)
+
+
+@pytest.fixture
+def failing_corpus_engagement_provider():
+    # Initialize the client with a non-existing feature group 'foobar', to simulate a Feature Store failure scenario.
+    feature_group_client = FeatureGroupClient(aioboto3_session=FeatureStoreMock('foobar').aioboto3)
     return CorpusEngagementProvider(feature_group_client)

--- a/tests/mocks/corpus_feature_group_client.py
+++ b/tests/mocks/corpus_feature_group_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.config import ROOT_DIR
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
+from tests.functional.test_util.caching import reset_caches
 from tests.mocks.feature_store_mock import FeatureStoreMock
 
 

--- a/tests/mocks/feature_store_mock.py
+++ b/tests/mocks/feature_store_mock.py
@@ -36,6 +36,7 @@ class FeatureStoreMock:
         # Use partial pass in 'self' so it can access attributes loaded during setup.
         context_feature_store_client.get_record.side_effect = partial(self._get_record_stub, self)
         context_feature_store_client.put_record.side_effect = partial(self._put_record_stub, self)
+        context_feature_store_client.batch_get_record.side_effect = partial(self._batch_get_record_stub, self)
 
     def _get_id_from_record(self, record: List[Dict]) -> str:
         """
@@ -69,6 +70,29 @@ class FeatureStoreMock:
         # Only return requested features to check that a valid model can be constructed from the requested features.
         filtered_record = [feature for feature in full_record if feature['FeatureName'] in feature_names]
         return {'Record': filtered_record}
+
+    def _batch_get_record_stub(self, *args, **kwargs):
+        errors = []
+        records = []
+
+        for identifier in kwargs['Identifiers']:
+            for record_identifier in identifier['RecordIdentifiersValueAsString']:
+                try:
+                    record = self._get_record_stub(
+                        RecordIdentifierValueAsString=record_identifier,
+                        FeatureGroupName=identifier['FeatureGroupName'],
+                        FeatureNames=identifier['FeatureNames'],
+                    )
+
+                    if record:
+                        records.append(record)
+                except BotoCoreError as e:
+                    errors.append({'ErrorMessage': str(e)})
+
+        if errors:
+            return {'Records': [], 'Errors': errors}
+        else:
+            return {'Records': []}
 
     def _put_record_stub(self, *args, **kwargs):
         feature_group_name = kwargs['FeatureGroupName']

--- a/tests/unit/data_providers/conftest.py
+++ b/tests/unit/data_providers/conftest.py
@@ -1,6 +1,7 @@
 import pytest  # noqa
 
-from tests.mocks.corpus_engagement_provider import corpus_engagement_provider  # noqa
+from tests.mocks.corpus_engagement_provider import *  # noqa
+from tests.mocks.caching import *  # noqa
 from tests.mocks.corpus_feature_group_client import corpus_feature_group_client  # noqa
 from tests.mocks.translation_provider import translation_provider  # noqa
 from tests.mocks.topic_provider import topic_provider_en_us  # noqa

--- a/tests/unit/data_providers/test_new_tab_slate_provider.py
+++ b/tests/unit/data_providers/test_new_tab_slate_provider.py
@@ -1,0 +1,48 @@
+import random
+
+import pytest
+
+from app.data_providers.slate_providers.new_tab_slate_provider import NewTabSlateProvider
+from app.models.corpus_item_model import CorpusItemModel
+from app.models.corpus_slate_lineup_model import RecommendationSurfaceId
+from app.models.localemodel import LocaleModel
+from tests.assets.topics import all_topic_fixtures
+
+
+@pytest.fixture
+def new_tab_slate_provider(corpus_feature_group_client, corpus_engagement_provider, translation_provider):
+    return NewTabSlateProvider(
+        corpus_feature_group_client=corpus_feature_group_client,
+        corpus_engagement_provider=corpus_engagement_provider,
+        recommendation_surface_id=RecommendationSurfaceId.NEW_TAB_EN_US,
+        locale=LocaleModel.en_US,
+        translation_provider=translation_provider,
+    )
+
+
+@pytest.fixture
+def new_tab_slate_provider_with_engagement_failure(new_tab_slate_provider, failing_corpus_engagement_provider):
+    new_tab_slate_provider.corpus_engagement_provider = failing_corpus_engagement_provider
+    return new_tab_slate_provider
+
+
+@pytest.mark.asyncio
+class TestNewTabSlateProvider:
+
+    async def test_rank_corpus_items(self, new_tab_slate_provider, caplog, aiocache_functions_fixture):
+        items = [CorpusItemModel(id=str(i), topic=random.choice(all_topic_fixtures).corpus_topic_id) for i in range(10)]
+
+        ranked_items = await new_tab_slate_provider.rank_corpus_items(items=items)
+
+        assert len(items) == len(ranked_items)
+        assert not any(r.levelname == 'ERROR' for r in caplog.records)
+
+    async def test_rank_corpus_items_with_engagement_failure(
+            self, new_tab_slate_provider_with_engagement_failure, caplog, aiocache_functions_fixture):
+        items = [CorpusItemModel(id=str(i), topic=random.choice(all_topic_fixtures).corpus_topic_id) for i in range(10)]
+
+        ranked_items = await new_tab_slate_provider_with_engagement_failure.rank_corpus_items(items=items)
+
+        # Recommendations should be returned (without Thompson sampling), and an error should be logged.
+        assert len(items) == len(ranked_items)
+        assert any(r.levelname == 'ERROR' for r in caplog.records)


### PR DESCRIPTION
# Goal
- Rank New Tab recommendations for the new markets using Thompson sampling.
- Recommendations should be served successfully even when aggregate engagement data is not available.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-456

## Implementation Decisions

## QA
In addition to the automated tests, I also tested that `newTabSlate` succeeds when the engagement Feature Group is unavailable.

### Feature Group is missing or renamed
Change the name of the Feature Group in `CorpusEngagementProvider`. The query successfully returns recommendations and the following error is logged:

> batch_get_record received 0 records and 47 errors. First error: {'FeatureGroupName': 'development-corpus-engagement-v123', 'RecordIdentifierValueAsString': 'NEW_TAB_EN_US/45f54436-46ea-5045-a753-f79a7e51c3ca/ffb9abaa-10d8-48c1-9afd-5bc8b3087353', 'ErrorCode': 'ValidationError', 'ErrorMessage': "Resource Not Found: Amazon SageMaker can't find a FeatureGroup with name [arn:aws:sagemaker:us-east-1:410318598490:feature-group/development-corpus-engagement-v123]."}

### Access to the Feature Group is denied
Remove the signature in `~/.aws/credentials`. The query successfully returns recommendations and the following error is logged:

> Getting engagement data from development-corpus-engagement-v123 caused an unexpected exception. Recommendations can still be served, but without Thompson sampling. An error occurred (InvalidSignatureException) when calling the BatchGetRecord operation: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.