### PR TITLE
fix(CircleCI): Snowplow connection error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ only_dev: &only_dev
 jobs:
   apollo:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:2023.02.1
       docker_layer_caching: true
     steps:
       - checkout
@@ -110,7 +110,7 @@ jobs:
 
   test_app:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:2023.02.1
       #docker_layer_caching: true  # This prevents the latest snowplow-micro image from being pulled.
     steps:
       - checkout


### PR DESCRIPTION
# Goal
Fix tests failing in CI because they can't connect to Snowplow Micro:

> requests.exceptions.ConnectionError: HTTPConnectionPool(host='snowplow', port=9090): Max retries exceeded with url: /micro/reset

## Root cause analysis
- The snowplow Docker container logs "No java installations was detected." and fails to start.
- Inside the Snowplow container Java says it has insufficient memory to start, despite that 6688 MB is available.
```
$ docker-compose exec snowplow java -Xmx2M -version
[0.002s][warning][os,thread] Failed to start thread "GC Thread#0" - pthread_create failed (EPERM) for attributes: stacksize: 1024k, guardsize: 4k, detached.
#
# There is insufficient memory for the Java Runtime Environment to continue.
```
- [Web/pull/4540](https://github.com/Pocket/Web/pull/4540) updated the [Snowplow Micro image](https://hub.docker.com/layers/pocket/snowplow-micro/latest/images/sha256-37b111b1b5e8927cda78176c797f54df6724de0c1df3ee9b9d922887857989f4?context=repo) last week, and switched to buildx.
- buildx comes with [several requirements](https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408), including docker >= 19.03.
- Updating the CircleCI machine image fixes the issue. Possibly our Docker version was too old.

## Reference

Slack thread:
* https://pocket.slack.com/archives/C02JZ4TRF0S/p1681773767056769

## Implementation Decisions
