### PR TITLE
feat(NewTab): Return content from new markets [DIS-403]

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -108,6 +108,10 @@ class Item2ItemDispatch:
 
 
 class HomeDispatch:
+    AVAILABLE_LOCALES = [
+        LocaleModel.en_US,
+        LocaleModel.de_DE,
+    ]
 
     def __init__(
             self,
@@ -258,6 +262,13 @@ class HomeDispatch:
 
 
 class NewTabDispatch:
+    AVAILABLE_LOCALES = [
+        LocaleModel.en_US,
+        LocaleModel.de_DE,
+        LocaleModel.es_ES,
+        LocaleModel.fr_FR,
+        LocaleModel.it_IT,
+    ]
 
     def __init__(self, new_tab_slate_provider: NewTabSlateProvider, snowplow: SnowplowCorpusRecommendationsTracker):
         self.new_tab_slate_provider = new_tab_slate_provider
@@ -278,11 +289,15 @@ class NewTabDispatch:
             )))
 
         return corpus_slate
+
     @staticmethod
     def get_recommendation_surface_id(locale: LocaleModel) -> RecommendationSurfaceId:
         surface_by_locale = {
             LocaleModel.en_US: RecommendationSurfaceId.NEW_TAB_EN_US,
             LocaleModel.de_DE: RecommendationSurfaceId.NEW_TAB_DE_DE,
+            LocaleModel.es_ES: RecommendationSurfaceId.NEW_TAB_ES_ES,
+            LocaleModel.fr_FR: RecommendationSurfaceId.NEW_TAB_FR_FR,
+            LocaleModel.it_IT: RecommendationSurfaceId.NEW_TAB_IT_IT,
         }
 
         return surface_by_locale[locale]

--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -1,13 +1,13 @@
 from typing import Optional, List
 
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.link import LinkModel
 from app.models.localemodel import LocaleModel
 from app.rankers.algorithms import thompson_sampling
 
 
-class CollectionSlateProvider(SlateProvider):
+class CollectionSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:

--- a/app/data_providers/slate_providers/for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/for_you_slate_provider.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Optional
 
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.recommendation_reason_model import RecommendationReasonModel
@@ -9,7 +9,7 @@ from app.models.topic import TopicModel
 from app.rankers.algorithms import rank_by_preferred_topics, spread_topics, rank_by_impression_caps, thompson_sampling
 
 
-class ForYouSlateProvider(SlateProvider):
+class ForYouSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:

--- a/app/data_providers/slate_providers/life_hacks_slate_provider.py
+++ b/app/data_providers/slate_providers/life_hacks_slate_provider.py
@@ -1,7 +1,7 @@
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 
 
-class LifeHacksSlateProvider(SlateProvider):
+class LifeHacksSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:

--- a/app/data_providers/slate_providers/new_tab_slate_provider.py
+++ b/app/data_providers/slate_providers/new_tab_slate_provider.py
@@ -5,7 +5,6 @@ from uuid import uuid5, UUID
 from app.data_providers.corpus.corpus_api_client import CorpusApiClient
 from app.data_providers.feature_group.corpus_engagement_provider import CorpusEngagementProvider
 from app.data_providers.slate_providers.slate_provider import SlateProvider
-from app.data_providers.translation import TranslationProvider
 from app.data_providers.util import integer_hash
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
@@ -28,8 +27,7 @@ class NewTabSlateProvider(SlateProvider):
             corpus_api_client: CorpusApiClient,
             corpus_engagement_provider: CorpusEngagementProvider,
             recommendation_surface_id: RecommendationSurfaceId,
-            locale: LocaleModel,
-            translation_provider: TranslationProvider):
+            locale: LocaleModel):
         """
         The only difference between this constructor and the parent one is that it explicitly requires a CorpusApiClient
         :param corpus_api_client: Client that gets corpus from Curated Corpus API.
@@ -38,8 +36,7 @@ class NewTabSlateProvider(SlateProvider):
             corpus_fetchable=corpus_api_client,
             corpus_engagement_provider=corpus_engagement_provider,
             recommendation_surface_id=recommendation_surface_id,
-            locale=locale,
-            translation_provider=translation_provider)
+            locale=locale)
 
         self.corpus_api_client = corpus_api_client
 

--- a/app/data_providers/slate_providers/pocket_hits_slate_provider.py
+++ b/app/data_providers/slate_providers/pocket_hits_slate_provider.py
@@ -2,11 +2,11 @@ from datetime import datetime, timedelta
 from typing import Optional
 import pytz
 
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.recommendation_reason_type import RecommendationReasonType
 
 
-class PocketHitsSlateProvider(SlateProvider):
+class PocketHitsSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:

--- a/app/data_providers/slate_providers/recommended_reads_slate_provider.py
+++ b/app/data_providers/slate_providers/recommended_reads_slate_provider.py
@@ -1,12 +1,12 @@
 from typing import List
 
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.localemodel import LocaleModel
 from app.rankers.algorithms import thompson_sampling
 
 
-class RecommendedReadsSlateProvider(SlateProvider):
+class RecommendedReadsSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:

--- a/app/data_providers/slate_providers/slate_provider.py
+++ b/app/data_providers/slate_providers/slate_provider.py
@@ -24,13 +24,11 @@ class SlateProvider(ABC):
         corpus_engagement_provider: CorpusEngagementProvider,
         recommendation_surface_id: RecommendationSurfaceId,
         locale: LocaleModel,
-        translation_provider: TranslationProvider,
     ):
         self.corpus_fetchable = corpus_fetchable
         self.corpus_engagement_provider = corpus_engagement_provider
         self.recommendation_surface_id = recommendation_surface_id
         self.locale = locale
-        self.home_translations = translation_provider.get_translations(self.locale, filename='home.json')
 
     @property
     @abstractmethod
@@ -54,14 +52,14 @@ class SlateProvider(ABC):
         """
         :return: Slate headline
         """
-        return self.home_translations[f'{self.provider_name}.headline']
+        return NotImplemented
 
     @property
     def subheadline(self) -> Optional[str]:
         """
         :return: (optional) Slate subheadline
         """
-        return self.home_translations.get(f'{self.provider_name}.subheadline', None)
+        return None
 
     @property
     def more_link(self) -> Optional[LinkModel]:
@@ -135,3 +133,30 @@ class SlateProvider(ABC):
                 recommendations=recommendations,
                 recommendation_reason_type=self.recommendation_reason_type,
             )
+
+
+class HomeSlateProvider(SlateProvider, ABC):
+    def __init__(
+            self,
+            corpus_fetchable: CorpusFetchable,
+            corpus_engagement_provider: CorpusEngagementProvider,
+            recommendation_surface_id: RecommendationSurfaceId, locale: LocaleModel,
+            translation_provider: TranslationProvider,
+    ):
+        super().__init__(corpus_fetchable, corpus_engagement_provider, recommendation_surface_id, locale)
+
+        self.home_translations = translation_provider.get_translations(self.locale, filename='home.json')
+
+    @property
+    def headline(self) -> str:
+        """
+        :return: Slate headline
+        """
+        return self.home_translations[f'{self.provider_name}.headline']
+
+    @property
+    def subheadline(self) -> Optional[str]:
+        """
+        :return: (optional) Slate subheadline
+        """
+        return self.home_translations.get(f'{self.provider_name}.subheadline', None)

--- a/app/data_providers/slate_providers/topic_slate_provider.py
+++ b/app/data_providers/slate_providers/topic_slate_provider.py
@@ -2,14 +2,14 @@ import random
 from typing import List, Optional
 
 from app.data_providers.slate_providers.candidate_sets import get_topic_candidate_set_id
-from app.data_providers.slate_providers.slate_provider import SlateProvider
+from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.link import LinkModel
 from app.models.localemodel import LocaleModel
 from app.models.topic import TopicModel
 
 
-class TopicSlateProvider(SlateProvider):
+class TopicSlateProvider(HomeSlateProvider):
     def __init__(self, topic: TopicModel, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.topic = topic

--- a/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_lineup_resolvers.py
@@ -32,7 +32,11 @@ async def resolve_home_slate_lineup(root, info: Info, locale: str = 'en-US') -> 
     di = DiContainer.get()
     user = get_request_user(info)
     api_client = get_pocket_client(info)
-    locale_model = LocaleModel.from_string(locale, default=LocaleModel.en_US)
+    locale_model = LocaleModel.from_string(
+        locale,
+        available_locales=HomeDispatch.AVAILABLE_LOCALES,
+        default=LocaleModel.en_US,
+    )
     topic_provider = TopicProvider(
         di.aioboto3_session,
         locale=locale_model,

--- a/app/graphql/resolvers/corpus_slate_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_resolvers.py
@@ -33,7 +33,11 @@ async def resolve_new_tab_slate(
                         " serve multiple markets with the same language.")],
 ) -> CorpusSlate:
     di = DiContainer.get()
-    locale_model = LocaleModel.from_string(locale, default=LocaleModel.en_US)
+    locale_model = LocaleModel.from_string(
+        locale,
+        available_locales=NewTabDispatch.AVAILABLE_LOCALES,
+        default=LocaleModel.en_US,
+    )
 
     async with PocketGraphClientSession(CorpusApiGraphConfig()) as graph_client_session:
         slate_model = await NewTabDispatch(
@@ -42,7 +46,6 @@ async def resolve_new_tab_slate(
                 recommendation_surface_id=NewTabDispatch.get_recommendation_surface_id(locale=locale_model),
                 corpus_engagement_provider=di.corpus_engagement_provider,
                 locale=locale_model,
-                translation_provider=di.translation_provider,
             ),
             snowplow=SnowplowCorpusRecommendationsTracker(
                 tracker=create_snowplow_tracker(),

--- a/app/models/corpus_slate_lineup_model.py
+++ b/app/models/corpus_slate_lineup_model.py
@@ -15,6 +15,9 @@ class RecommendationSurfaceId(Enum):
     HOME = 'HOME'
     NEW_TAB_EN_US = 'NEW_TAB_EN_US'
     NEW_TAB_DE_DE = 'NEW_TAB_DE_DE'
+    NEW_TAB_ES_ES = 'NEW_TAB_ES_ES'
+    NEW_TAB_FR_FR = 'NEW_TAB_FR_FR'
+    NEW_TAB_IT_IT = 'NEW_TAB_IT_IT'
 
 
 class CorpusSlateLineupModel(BaseModel):

--- a/app/models/localemodel.py
+++ b/app/models/localemodel.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List
 
 
 class LocaleValue(str):
@@ -14,15 +15,22 @@ class LocaleValue(str):
 class LocaleModel(Enum):
     en_US = LocaleValue('en-US')
     de_DE = LocaleValue('de-DE')
+    es_ES = LocaleValue('es-ES')
+    fr_FR = LocaleValue('fr-FR')
+    it_IT = LocaleValue('it-IT')
 
-    @classmethod
-    def from_string(cls, val: str, default: 'LocaleModel' = None) -> 'LocaleModel':
-        for locale in cls:
+    @staticmethod
+    def from_string(val: str, available_locales: List['LocaleModel'], default: 'LocaleModel' = None) -> 'LocaleModel':
+        """
+        :return: The first value in `available_locales` that equals `val` (case-insensitive), otherwise the first locale
+                 which language matches the part of `val` before a hyphen (case-insensitive), otherwise the default.
+        """
+        for locale in available_locales:
             if locale.value.lower() == val.lower():
                 return locale
 
         language = val.split('-')[0].lower()
-        for locale in cls:
+        for locale in available_locales:
             if locale.value.startswith(language):
                 return locale
 

--- a/tests/unit/data_providers/test_new_tab_dispatch.py
+++ b/tests/unit/data_providers/test_new_tab_dispatch.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.data_providers.dispatch import NewTabDispatch
+from app.models.corpus_slate_lineup_model import RecommendationSurfaceId
+from app.models.localemodel import LocaleModel
+
+
+@pytest.mark.parametrize(
+    "locale,recommendation_surface_id",
+    [
+        (LocaleModel.en_US, RecommendationSurfaceId.NEW_TAB_EN_US),
+        (LocaleModel.de_DE, RecommendationSurfaceId.NEW_TAB_DE_DE),
+        (LocaleModel.es_ES, RecommendationSurfaceId.NEW_TAB_ES_ES),
+        (LocaleModel.fr_FR, RecommendationSurfaceId.NEW_TAB_FR_FR),
+        (LocaleModel.it_IT, RecommendationSurfaceId.NEW_TAB_IT_IT),
+    ])
+def test_get_recommendation_surface_id(locale: LocaleModel, recommendation_surface_id: RecommendationSurfaceId):
+    assert recommendation_surface_id == NewTabDispatch.get_recommendation_surface_id(locale)

--- a/tests/unit/data_providers/test_new_tab_slate_provider.py
+++ b/tests/unit/data_providers/test_new_tab_slate_provider.py
@@ -11,13 +11,12 @@ from tests.assets.topics import all_topic_fixtures
 
 
 @pytest.fixture
-def new_tab_slate_provider(corpus_api_client, corpus_engagement_provider, translation_provider):
+def new_tab_slate_provider(corpus_api_client, corpus_engagement_provider):
     return NewTabSlateProvider(
         corpus_api_client=corpus_api_client,
         corpus_engagement_provider=corpus_engagement_provider,
         recommendation_surface_id=RecommendationSurfaceId.NEW_TAB_EN_US,
-        locale=LocaleModel.en_US,
-        translation_provider=translation_provider,
+        locale=LocaleModel.en_US
     )
 
 

--- a/tests/unit/models/test_locale_model.py
+++ b/tests/unit/models/test_locale_model.py
@@ -1,25 +1,33 @@
 from app.models.localemodel import LocaleModel
 
 
+_ALL_LOCALES = list(LocaleModel.__members__.values())
+
+
 def test_from_string_full_locale():
-    assert LocaleModel.en_US == LocaleModel.from_string('en-US')
-    assert LocaleModel.en_US == LocaleModel.from_string('en-us')
-    assert LocaleModel.de_DE == LocaleModel.from_string('de-DE')
-    assert LocaleModel.de_DE == LocaleModel.from_string('de-de')
+    assert LocaleModel.en_US == LocaleModel.from_string('en-US', _ALL_LOCALES)
+    assert LocaleModel.en_US == LocaleModel.from_string('en-us', _ALL_LOCALES)
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-DE', _ALL_LOCALES)
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-de', _ALL_LOCALES)
 
 
 def test_from_string_language_match():
-    assert LocaleModel.de_DE == LocaleModel.from_string('de-AT')
-    assert LocaleModel.en_US == LocaleModel.from_string('en-CA')
+    assert LocaleModel.de_DE == LocaleModel.from_string('de-AT', _ALL_LOCALES)
+    assert LocaleModel.en_US == LocaleModel.from_string('en-CA', _ALL_LOCALES)
 
 
 def test_from_string_language_only():
-    assert LocaleModel.en_US == LocaleModel.from_string('en')
-    assert LocaleModel.en_US == LocaleModel.from_string('EN')
-    assert LocaleModel.de_DE == LocaleModel.from_string('de')
-    assert LocaleModel.de_DE == LocaleModel.from_string('DE')
+    assert LocaleModel.en_US == LocaleModel.from_string('en', _ALL_LOCALES)
+    assert LocaleModel.en_US == LocaleModel.from_string('EN', _ALL_LOCALES)
+    assert LocaleModel.de_DE == LocaleModel.from_string('de', _ALL_LOCALES)
+    assert LocaleModel.de_DE == LocaleModel.from_string('DE', _ALL_LOCALES)
 
 
 def test_from_string_default():
-    assert LocaleModel.from_string('xx-YY') is None
-    assert LocaleModel.en_US == LocaleModel.from_string('xx-YY', LocaleModel.en_US)
+    assert LocaleModel.from_string('xx-YY', _ALL_LOCALES) is None
+    assert LocaleModel.en_US == LocaleModel.from_string('xx-YY', _ALL_LOCALES, LocaleModel.en_US)
+
+
+def test_from_string_accepted_locales():
+    assert LocaleModel.from_string('de-DE', [LocaleModel.en_US]) is None
+    assert LocaleModel.en_US == LocaleModel.from_string('en', [LocaleModel.en_US])


### PR DESCRIPTION
# Goal
Return NewTab content for the 3 new markets based on the requested locale.

## Deployment
- [ ] Content should be available reliably for all locales starting from April 25th forward. At that point the tests should pass.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-403

## Implementation decisions
- Add a new class `HomeSlateProvider` to contain the Home translations. Those aren't relevant to NewTab.