### PR TITLE
chore(elasticache): update elasticache node type to t3.micro

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -12,7 +12,7 @@ const domain = isDev
 
 // aiocache currently does not support data partitioning, so there's little benefit to having more than 1 node.
 const cacheNodes = isDev ? 1 : 1;
-const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';
+const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.medium';
 
 export const config = {
   name,


### PR DESCRIPTION
# Goal

Update elasticache node type to t3.micro from t2.micro which is no longer supported for reserved instance pricing

Tickets:[
* https://mozilla-hub.atlassian.net/browse/SE-3462


