### PR TITLE
Add support of hasUserModel Unleash strategy

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -185,7 +185,8 @@ class HomeDispatch:
             4. 'Life Hacks' slate
             5. Topic slates according to preferred topics if available, otherwise default topics.
         """
-        slates = []
+        if self.hybrid_cf_slate_provider.can_recommend(user):
+            user.user_models.append('hybrid_cf')
 
         user_impression_capped_list, \
         preferred_topics, \
@@ -200,6 +201,7 @@ class HomeDispatch:
             thompson_sampling_asn is not None and thompson_sampling_asn.variant == 'treatment'
         enable_hybrid_cf = cf_asn is not None and cf_asn.variant == 'treatment'
 
+        slates = []
         if enable_hybrid_cf and self.hybrid_cf_slate_provider.can_recommend(user):
             slates += [self.hybrid_cf_slate_provider.get_slate(user=user,
                                                                user_impression_capped_list=user_impression_capped_list)]

--- a/app/data_providers/unleash_provider.py
+++ b/app/data_providers/unleash_provider.py
@@ -87,11 +87,15 @@ class UnleashProvider:
                     'userId': user.hashed_user_id,
                     'sessionId': user.hashed_guid,
                     'properties': {
-                        'locale': user.locale,
+                        'locale': user.locale
                     }
                 }
             }
         }
+
+        if user.user_models:
+            # not really related to recit anymore, but it's what the unleash strategy hasUserModel expects
+            body['variables']['context']['properties']['recItUserProfile'] = {'userModels': user.user_models}
 
         async with self.pocket_graph_client_session.post(url='/', json=body, raise_for_status=True) as resp:
             response_json = await resp.json()

--- a/app/models/request_user.py
+++ b/app/models/request_user.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic import BaseModel
 
 
@@ -8,6 +10,7 @@ class RequestUser(BaseModel):
     - hashed_user_id: hashed (encoded) user_id. Not present on logged-out requests.
     - guid: integer identifier that is consistent across sessions.
     - hashed_user_id: hashed (encoded) guid.
+    - user_models: models to use in hasUserModel Unleash strategy
     """
 
     user_id: int = None
@@ -15,3 +18,4 @@ class RequestUser(BaseModel):
     guid: int = None
     hashed_guid: str = None
     locale: str = None  # e.g. en-US
+    user_models: List[str] = []


### PR DESCRIPTION
# Goal

Being able to enroll in an experiment only users that are supported by the model

- [x] tested on dev feature flags + recAPI

Tickets:
*[ Link to JIRA tickets](https://getpocket.atlassian.net/browse/DIS-756)

## Implementation Decisions

Use the existing `hasUserModel` strategy that was developed for recit. It works well here, the only downside that it says recit in property name.
