### PR TITLE
fix: Link Canary alarm to runbook

### DIFF
--- a/.aws/src/monitoring.ts
+++ b/.aws/src/monitoring.ts
@@ -184,7 +184,7 @@ export class RecommendationApiSynthetics extends Construct {
     );
 
     new cloudwatch.CloudwatchMetricAlarm(this, 'synthetic_check_alarm', {
-      alarmDescription: `Alert when ${synCheckCanary.name} canary success percentage has decreased below 66% in the last 15 minutes`,
+      alarmDescription: `Runbook: https://getpocket.atlassian.net/l/cp/5wQMswfT`,
       alarmName: `pocket-${synCheckCanary.name}-synthetic-check-access`,
 
       comparisonOperator: 'LessThanThreshold',


### PR DESCRIPTION
# Goal
Link the synthetic canary alarm to the corresponding runbook.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-762