### PR TITLE
Replace TS experiment with HybridCF

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -190,15 +190,12 @@ class HomeDispatch:
 
         user_impression_capped_list, \
         preferred_topics, \
-        assignments = await gather(
+        unleash_asn = await gather(
             self.user_impression_cap_provider.get(user),
             self._get_preferred_topics(user),
-            self.unleash_provider.get_assignments(['temp.web.recommendation-api.home.thompson-sampling-rerun',
-                                                   'temp.web.recommendation-api.home.hybrid_cf_test'], user=user))
+            self.unleash_provider.get_assignments(['temp.web.recommendation-api.home.hybrid_cf_test'], user=user))
 
-        thompson_sampling_asn, cf_asn = assignments
-        enable_thompson_sampling = \
-            thompson_sampling_asn is not None and thompson_sampling_asn.variant == 'treatment'
+        cf_asn = unleash_asn[0]
         enable_hybrid_cf = cf_asn is not None and cf_asn.variant == 'treatment'
 
         slates = []
@@ -209,17 +206,14 @@ class HomeDispatch:
             if preferred_topics:
                 slates += [self.for_you_slate_provider.get_slate(
                     preferred_topics=preferred_topics,
-                    user_impression_capped_list=user_impression_capped_list,
-                    enable_thompson_sampling=enable_thompson_sampling,
+                    user_impression_capped_list=user_impression_capped_list
                 )]
             else:
-                slates += [self.recommended_reads_slate_provider.get_slate(
-                    enable_thompson_sampling=enable_thompson_sampling
-                )]
+                slates += [self.recommended_reads_slate_provider.get_slate()]
 
         slates += [
             self.pocket_hits_slate_provider.get_slate(),
-            self.collection_slate_provider.get_slate(enable_thompson_sampling=enable_thompson_sampling),
+            self.collection_slate_provider.get_slate(),
             self.life_hacks_slate_provider.get_slate(),
         ]
 
@@ -230,10 +224,7 @@ class HomeDispatch:
                 slates=list(await gather(*slates)),
                 recommendation_count=recommendation_count,
             ),
-            recommendation_surface_id=RecommendationSurfaceId.HOME,
-            locale=locale,
-            experiment=thompson_sampling_asn,
-        ), thompson_sampling_asn
+        ), cf_asn
 
     async def get_de_de_slate_lineup(self, recommendation_count: int, locale: LocaleModel) -> \
             Tuple[CorpusSlateLineupModel, Optional[UnleashAssignmentModel]]:
@@ -257,7 +248,6 @@ class HomeDispatch:
                 slates=list(await gather(*slates)),
                 recommendation_count=recommendation_count,
             ),
-            locale=locale,
         ), None
 
     @staticmethod

--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -32,17 +32,16 @@ class CollectionSlateProvider(HomeSlateProvider):
     ) -> List[CorpusItemModel]:
         """
         :param items: Candidate corpus items
-        :return: Ranks items based on Thompson sampling if enable_thompson_sampling is True.
+        :return: Ranks items based on Thompson sampling.
         """
-        if kwargs.get('enable_thompson_sampling'):
-            metrics = await self.corpus_engagement_provider.get(
-                self.recommendation_surface_id, self.configuration_id, items)
+        metrics = await self.corpus_engagement_provider.get(
+            self.recommendation_surface_id, self.configuration_id, items)
 
-            items = thompson_sampling(
-                recs=items,
-                metrics=metrics,
-                trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
-                default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
-                default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+        items = thompson_sampling(
+            recs=items,
+            metrics=metrics,
+            trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
+            default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
+            default_beta_prior=1200)  # 20% of average daily item impressions for this slate
 
         return items

--- a/app/data_providers/slate_providers/for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/for_you_slate_provider.py
@@ -41,18 +41,15 @@ class ForYouSlateProvider(HomeSlateProvider):
         assert preferred_topics is not None
         assert user_impression_capped_list is not None
 
-        if kwargs.get('enable_thompson_sampling'):
-            metrics = await self.corpus_engagement_provider.get(
-                self.recommendation_surface_id, self.configuration_id, items)
+        metrics = await self.corpus_engagement_provider.get(
+            self.recommendation_surface_id, self.configuration_id, items)
 
-            items = thompson_sampling(
-                recs=items,
-                metrics=metrics,
-                trailing_period=14,  # A long period might work better given that some topics get few impressions
-                default_alpha_prior=20,  # beta * P95 item CTR for this slate (1.6%)
-                default_beta_prior=1200)  # 5% of average daily item impressions for this slate
-        else:
-            random.shuffle(items)
+        items = thompson_sampling(
+            recs=items,
+            metrics=metrics,
+            trailing_period=14,  # A long period might work better given that some topics get few impressions
+            default_alpha_prior=20,  # beta * P95 item CTR for this slate (1.6%)
+            default_beta_prior=1200)  # 5% of average daily item impressions for this slate
 
         items = rank_by_impression_caps(items, user_impression_capped_list)
         items = spread_topics(items)

--- a/app/data_providers/slate_providers/recommended_reads_slate_provider.py
+++ b/app/data_providers/slate_providers/recommended_reads_slate_provider.py
@@ -25,17 +25,17 @@ class RecommendedReadsSlateProvider(HomeSlateProvider):
     ) -> List[CorpusItemModel]:
         """
         :param items: Candidate corpus items
-        :return: Ranks items based on Thompson sampling if enable_thompson_sampling is True.
+        :return: Ranks items based on Thompson sampling.
         """
-        if kwargs.get('enable_thompson_sampling'):
-            metrics = await self.corpus_engagement_provider.get(
-                self.recommendation_surface_id, self.configuration_id, items)
 
-            items = thompson_sampling(
-                recs=items,
-                metrics=metrics,
-                trailing_period=7,  # With few new items/day and relatively many impressions, a low period is sufficient
-                default_alpha_prior=12,   # beta * P95 item CTR for this slate (0.7%)
-                default_beta_prior=1700)  # 5% of average daily item impressions for this slate
+        metrics = await self.corpus_engagement_provider.get(
+            self.recommendation_surface_id, self.configuration_id, items)
+
+        items = thompson_sampling(
+            recs=items,
+            metrics=metrics,
+            trailing_period=7,  # With few new items/day and relatively many impressions, a low period is sufficient
+            default_alpha_prior=12,   # beta * P95 item CTR for this slate (0.7%)
+            default_beta_prior=1700)  # 5% of average daily item impressions for this slate
 
         return items

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -123,8 +123,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
         preferences_fixture = _user_recommendation_preferences_fixture(str(self.request_user.user_id), preferred_topics)
         mock_fetch_user_recommendation_preferences.return_value = preferences_fixture
         mock_get_user_impression_caps.return_value = corpus_items_fixture[:6]
-        mock_get_all_assignments.return_value = [UnleashAssignmentModel(
-            assigned=True, name='temp.web.recommendation-api.home.thompson-sampling-rerun', variant='control')]
+        mock_get_all_assignments.return_value = []
 
         async with AsyncClient(app=app, base_url="http://test") as client, LifespanManager(app):
             response = await client.post('/', json={'query': HOME_SLATE_LINEUP_QUERY}, headers=self.headers)
@@ -153,7 +152,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 2, 'good': 2, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -172,8 +171,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
         mock_fetch_corpus_items.return_value = corpus_items_fixture
         mock_fetch_user_recommendation_preferences.return_value = None  # User has does not have a preferences record
         mock_get_user_impression_caps.return_value = corpus_items_fixture[:6]
-        mock_get_all_assignments.return_value = [UnleashAssignmentModel(
-            assigned=True, name='temp.web.recommendation-api.home.thompson-sampling-rerun', variant='control')]
+        mock_get_all_assignments.return_value = []
 
         async with AsyncClient(app=app, base_url="http://test") as client, LifespanManager(app):
             response = await client.post('/', json={'query': HOME_SLATE_LINEUP_QUERY}, headers=self.headers)
@@ -195,39 +193,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 2, 'good': 2, 'bad': 0}
-
-    @patch.object(CorpusFeatureGroupClient, 'fetch')
-    @patch.object(UserRecommendationPreferencesProvider, 'fetch')
-    @patch.object(UserImpressionCapProvider, 'get')
-    @patch.object(UnleashProvider, '_get_all_assignments')
-    @patch.object(FeatureGroupClient, 'batch_get_records')
-    async def test_thompson_sampling_unpersonalized_home_slate_lineup(
-            self,
-            mock_batch_get_records,
-            mock_get_all_assignments,
-            mock_get_user_impression_caps,
-            mock_fetch_user_recommendation_preferences,
-            mock_fetch_corpus_items,
-    ):
-        corpus_items_fixture = _corpus_items_fixture(n=100)
-        mock_fetch_corpus_items.return_value = corpus_items_fixture
-        mock_fetch_user_recommendation_preferences.return_value = None  # User has does not have a preferences record
-        mock_get_user_impression_caps.return_value = corpus_items_fixture[:6]
-        mock_get_all_assignments.return_value = [UnleashAssignmentModel(
-            assigned=True, name='temp.web.recommendation-api.home.thompson-sampling-rerun', variant='treatment')]
-        mock_batch_get_records.return_value = []
-
-        async with AsyncClient(app=app, base_url="http://test") as client, LifespanManager(app):
-            response = await client.post('/', json={'query': HOME_SLATE_LINEUP_QUERY}, headers=self.headers)
-            data = response.json()
-
-            assert not data.get('errors')
-            slates = data['data']['homeSlateLineup']['slates']
-
-            await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
-            all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 2, 'good': 2, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -287,10 +253,9 @@ class TestHomeSlateLineup(TestDynamoDBBase):
         preferences_fixture = _user_recommendation_preferences_fixture(str(self.request_user.user_id), preferred_topics)
         mock_fetch_user_recommendation_preferences.return_value = preferences_fixture
         mock_get_user_impression_caps.return_value = corpus_items_fixture[:6]
-        mock_get_all_assignments.return_value = [UnleashAssignmentModel(
-            assigned=True, name='temp.web.recommendation-api.home.thompson-sampling-rerun', variant='control'),
+        mock_get_all_assignments.return_value = [
             UnleashAssignmentModel(
-                assigned=True, name='temp.web.recommendation-api.home.hybrid_cf_test', variant='treatment'),
+                assigned=True, name='temp.web.recommendation-api.home.hybrid_cf_test', variant='treatment')
         ]
 
         async with AsyncClient(app=app, base_url="http://test") as client, LifespanManager(app):


### PR DESCRIPTION
# Goal

1. Permanently integrate Thompson Sampling.
2. Enable sending events for the Hybrid Collaborative Filtering experiment.

The merge of this PR should be coordinated with @lfishhead and product folks + we'll need to configure `hasModelStrategy=hybrid_cf` in Unleash. Screenshots from dev of how it should look like:

<img width="1329" alt="Screenshot 2023-05-26 at 11 49 30 AM" src="https://github.com/Pocket/recommendation-api/assets/2486505/e21c2ef2-c2f6-4d71-a6da-50572e2628cb">
<img width="1361" alt="Screenshot 2023-05-26 at 11 49 38 AM" src="https://github.com/Pocket/recommendation-api/assets/2486505/6ddb1866-e393-4aa8-b9d6-6bdb3fefb257">


## Reference

Tickets:
* [Link to JIRA tickets](https://getpocket.atlassian.net/browse/DIS-605)

## Implementation Decisions
- This implementation of HybridCF provider does only impression capping without topic spreading and filtering by preferred topics.

