### PR TITLE
feat: Sentry transaction is set to graphql operationName

### DIFF
--- a/app/graphql/sentry_graphql_middleware.py
+++ b/app/graphql/sentry_graphql_middleware.py
@@ -1,0 +1,104 @@
+# Adapted from https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/fastapi.py
+# This integration differs only slightly from the FastApiIntegration:
+# - event_processor() sets the Sentry transaction name to be the GraphQL operationName
+# - only enable if graphql can be imported
+import asyncio
+
+from sentry_sdk.hub import Hub
+from sentry_sdk.integrations import DidNotEnable
+
+from typing import Any, Callable, Dict
+from sentry_sdk.scope import Scope
+from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
+
+try:
+    from sentry_sdk.integrations.starlette import (
+        StarletteIntegration,
+        StarletteRequestExtractor,
+    )
+except DidNotEnable:
+    raise DidNotEnable("Starlette is not installed")
+
+try:
+    import fastapi  # type: ignore
+except ImportError:
+    raise DidNotEnable("FastAPI is not installed")
+
+try:
+    import graphql  # type: ignore
+except ImportError:
+    raise DidNotEnable("graphql-core is not installed")
+
+
+class GraphqlIntegration(StarletteIntegration):
+    identifier = "graphql"
+
+    @staticmethod
+    def setup_once():
+        # type: () -> None
+        patch_get_request_handler()
+
+
+def patch_get_request_handler():
+    # type: () -> None
+    old_get_request_handler = fastapi.routing.get_request_handler
+
+    def _sentry_get_request_handler(*args, **kwargs):
+        # type: (*Any, **Any) -> Any
+        dependant = kwargs.get("dependant")
+        if (
+            dependant
+            and dependant.call is not None
+            and not asyncio.iscoroutinefunction(dependant.call)
+        ):
+            old_call = dependant.call
+
+            def _sentry_call(*args, **kwargs):
+                # type: (*Any, **Any) -> Any
+                hub = Hub.current
+                with hub.configure_scope() as sentry_scope:
+                    if sentry_scope.profile is not None:
+                        sentry_scope.profile.update_active_thread_id()
+                    return old_call(*args, **kwargs)
+
+            dependant.call = _sentry_call
+
+        old_app = old_get_request_handler(*args, **kwargs)
+
+        async def _sentry_app(*args, **kwargs):
+            # type: (*Any, **Any) -> Any
+            hub = Hub.current
+            integration = hub.get_integration(GraphqlIntegration)
+            if integration is None:
+                return await old_app(*args, **kwargs)
+
+            with hub.configure_scope() as sentry_scope:
+                request = args[0]
+                extractor = StarletteRequestExtractor(request)
+                info = await extractor.extract_request_info()
+
+                def _make_request_event_processor(req, integration):
+                    # type: (Any, Any) -> Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
+                    def event_processor(event, hint):
+                        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+                        if info:
+                            if "data" in info:
+                                data = info["data"]
+                                if "operationName" in data:
+                                    event["transaction"] = data["operationName"]
+                                    event["transaction_info"] = {"source": TRANSACTION_SOURCE_COMPONENT}
+
+                        return event
+
+                    return event_processor
+
+                sentry_scope._name = GraphqlIntegration.identifier
+                sentry_scope.add_event_processor(
+                    _make_request_event_processor(request, integration)
+                )
+
+            return await old_app(*args, **kwargs)
+
+        return _sentry_app
+
+    fastapi.routing.get_request_handler = _sentry_get_request_handler


### PR DESCRIPTION
# Goal
Add the GraphQL operation name as a searchable tag to Sentry. This has several benefits:
1. It's immediately clear which operation causes a Sentry error, because Sentry will show a histogram of operations with each issue.
2. We can search for operations in Sentry.
3. We can define different alert rules or thresholds for particular operations.

## Before
`transaction` was always set to `/`, because all GraphQL queries are served from this route. There was no way to search by the GraphQL query or operation in Sentry. The 'body' field does contain the operation name, but this field is not indexed.

![image](https://github.com/Pocket/recommendation-api/assets/1547251/682163c4-ce9c-4a77-8dec-ea16774e9890)

## After
`transaction` is set to the GraphQL operation name. This is a [searchable property](https://docs.sentry.io/product/sentry-basics/search/searchable-properties/) in Sentry, so we can now [search](https://pocket.sentry.io/issues/?limit=5&project=5503693&query=is%3Aunresolved+transaction%3ANewTabSlate&referrer=performance-related-issues&sort=new&statsPeriod=14d) and [alert](https://pocket.sentry.io/alerts/rules/recommendation-api/14455029/) for specific GraphQL operations.

![image](https://github.com/Pocket/recommendation-api/assets/1547251/b0b53520-c259-4e54-8ca2-a2a56ed2e016)

The Sentry transaction is a tag that alerts can filter on:

![Screenshot from 2023-06-02 14-54-22](https://github.com/Pocket/recommendation-api/assets/1547251/d6c046cd-2c8a-42aa-8e8d-690d4cff0bdf)

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-791

PR against sentry-python:
* https://github.com/getsentry/sentry-python/pull/2150

## Implementation Decisions
- https://github.com/getsentry/sentry-python/pull/2150 adds a searchable tag to the Python sentry-sdk library. If this is merged and released, we can update sentry-sdk and remove this custom Sentry integration.