### PR TITLE
drop the sessionId from the unleash query

### DIFF
--- a/app/data_providers/unleash_provider.py
+++ b/app/data_providers/unleash_provider.py
@@ -85,7 +85,6 @@ class UnleashProvider:
                     'appName': self.unleash_config.APP_NAME,
                     'environment': self.unleash_config.ENVIRONMENT,
                     'userId': user.hashed_user_id,
-                    'sessionId': user.hashed_guid,
                     'properties': {
                         'locale': user.locale
                     }

--- a/tests/functional/data_providers/test_unleash_provider.py
+++ b/tests/functional/data_providers/test_unleash_provider.py
@@ -28,13 +28,13 @@ async def test_get_assignments(pocket_graph_server: TestServer, user_1: RequestU
     request = pocket_graph_server.app['requests'][-1]
     request_json = await request.json()
     assert 'unleashAssignments' in request_json['query']
+    
     assert request_json['variables']['context'] == {
         'appName': unleash_config.APP_NAME,
         'environment': unleash_config.ENVIRONMENT,
         'userId': user_1.hashed_user_id,
-        'sessionId': user_1.hashed_guid,
         'properties': {'locale': user_1.locale}
-    }
+    } 
 
     # pocket_graph_server returns data from `tests/assets/json/unleash_assignments.json`
     assert unleash_assignments == [UnleashAssignmentModel(assigned=True, name='test.getstarted', variant='v0')]


### PR DESCRIPTION
# Goal
Some users are assigned to more than one treatment variant.
https://pocket.slack.com/archives/C02JZ4TRF0S/p1686265277754779?thread_ts=1686251034.146639&cid=C02JZ4TRF0S

One of the suspects is the presence of sessionId in the unleash call. We wanted to verify if that is helpful

## Todos
- [x] Outstanding todo
- [x] Completed todo

## Review
- [x] Security @ReviewerA
- [x] Test coverage @ReviewerC
- [ ] ...


Have you followed the guidelines in our Contributing document?

## Deployment
- [ ] Secrets?

## Reference

Tickets:
* Link to JIRA tickets

## Implementation Decisions
