### PR TITLE
Increase memory

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -159,7 +159,7 @@ class RecommendationAPI extends TerraformStack {
             domain: config.domain,
             taskSize: {
                 cpu: 4096,
-                memory: 8192,
+                memory: 16384,
             },
             containerConfigs: [
                 {

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -159,7 +159,7 @@ class RecommendationAPI extends TerraformStack {
             domain: config.domain,
             taskSize: {
                 cpu: 4096,
-                memory: 16384,
+                memory: 12288,
             },
             containerConfigs: [
                 {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@1.2.1
   aws-ecs: circleci/aws-ecs@2.0.0
-  pocket: pocket/circleci-orbs@1.2.5
+  pocket: pocket/circleci-orbs@2.1.2
 
 # Workflow shortcuts
 not_main: &not_main


### PR DESCRIPTION
# Goal

Fix ratio memory/core after deployment reconfiguration. We anticipate the ML model that takes most of the space to grow in the next version. Also, I think it's better to be on the safe side and have lower memory utilization than 70%. The model is reloaded periodically and updated by metaflow. It can suddenly become slightly larger. Even though we have some checks for its size in the reloading code we do not want to end up with OOM, it's better to leave some buffer.

Also, update CI orb.

This is a copy of this PR https://github.com/Pocket/recommendation-api/pull/1049 which I couldn't land because of the unsigned commits.
