### PR TITLE
Add start period to the healthcheck

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -175,7 +175,7 @@ class RecommendationAPI extends TerraformStack {
                         interval: 15,
                         retries: 3,
                         timeout: 5,
-                        startPeriod: 0,
+                        startPeriod: 60,
                     },
                     envVars: [
                         {


### PR DESCRIPTION
# Goal

The deployment fails because it takes about a minute to start the app with the new model loading. 

Let's add a 60-second starting period before the health check kicks in.
