### PR TITLE
feat(CorpusSlate): Add utm_source

### DIFF
--- a/app/data_providers/slate_providers/slate_provider.py
+++ b/app/data_providers/slate_providers/slate_provider.py
@@ -90,6 +90,14 @@ class SlateProvider(ABC):
         """
         return None
 
+    @property
+    def utm_source(self) -> str:
+        """
+        :return: utm_source value to attribute recommendations to, based on the recommendation_surface_id.
+        """
+        utm_source_surface = self.recommendation_surface_id.value.lower().replace('_', '-').replace('new-tab', 'newtab')
+        return f'pocket-{utm_source_surface}'
+
     async def get_candidate_corpus_items(self, *args, **kwargs) -> List[CorpusItemModel]:
         """
         :return: The CorpusItems from the candidate set, without any rankers or filters applied.
@@ -130,6 +138,7 @@ class SlateProvider(ABC):
                 more_link=self.more_link,
                 recommendations=recommendations,
                 recommendation_reason_type=self.recommendation_reason_type,
+                utm_source=self.utm_source,
             )
 
 

--- a/app/graphql/corpus_slate.py
+++ b/app/graphql/corpus_slate.py
@@ -21,3 +21,4 @@ class CorpusSlate:
         description='Recommendations for the current request context.')
     recommendation_reason_type: Optional[RecommendationReasonType]
     more_link: strawberry.auto
+    utm_source: strawberry.auto

--- a/app/models/corpus_slate_model.py
+++ b/app/models/corpus_slate_model.py
@@ -33,6 +33,9 @@ class CorpusSlateModel(BaseModel):
         default=None,
         description='Link to a page where the user can explore more recommendations similar to this slate, or null if '
                     'no link is provided.')
+    utm_source: Optional[str] = Field(
+        default=None,
+        description='utm_source value that can be set on the url by the caller to attribute the recommendations.')
 
     def remove_corpus_items(self, corpus_item_ids: Set[str]) -> 'CorpusSlateModel':
         """

--- a/tests/unit/data_providers/test_new_tab_slate_provider.py
+++ b/tests/unit/data_providers/test_new_tab_slate_provider.py
@@ -138,3 +138,27 @@ class TestNewTabSlateProvider:
         # Recommendations should be returned (without Thompson sampling), and an error should be logged.
         assert len(corpus_items_10) == len(ranked_items)
         assert any(r.levelname == 'ERROR' for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        ('recommendation_surface_id', 'expected_utm_source'),
+        [
+            (RecommendationSurfaceId.NEW_TAB_EN_US, 'pocket-newtab-en-us'),
+            (RecommendationSurfaceId.NEW_TAB_EN_GB, 'pocket-newtab-en-gb'),
+            (RecommendationSurfaceId.NEW_TAB_EN_INTL, 'pocket-newtab-en-intl'),
+            (RecommendationSurfaceId.NEW_TAB_DE_DE, 'pocket-newtab-de-de'),
+            (RecommendationSurfaceId.NEW_TAB_ES_ES, 'pocket-newtab-es-es'),
+            (RecommendationSurfaceId.NEW_TAB_FR_FR, 'pocket-newtab-fr-fr'),
+            (RecommendationSurfaceId.NEW_TAB_IT_IT, 'pocket-newtab-it-it'),
+        ]
+    )
+    async def test_rank_corpus_items(
+            self, recommendation_surface_id, expected_utm_source, corpus_api_client, corpus_engagement_provider):
+        new_tab_slate_provider = NewTabSlateProvider(
+            corpus_api_client=corpus_api_client,
+            corpus_engagement_provider=corpus_engagement_provider,
+            recommendation_surface_id=recommendation_surface_id,
+        )
+
+        slate = await new_tab_slate_provider.get_slate()
+
+        assert expected_utm_source == slate.utm_source


### PR DESCRIPTION
# Goal
Return `utm_source` value per [API proposal](https://getpocket.atlassian.net/wiki/spaces/PE/pages/3000958977/NewTab+utm+source#utm_source-values). Analytics requires NewTab recommendation URLs to have a `utm_source` identifier that is unique per NewTab market.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/DIS-803