### PR TITLE
feat(NewTab): Boost syndicated article to position 1

### DIFF
--- a/app/data_providers/corpus/corpus_api_client.py
+++ b/app/data_providers/corpus/corpus_api_client.py
@@ -23,8 +23,8 @@ class CorpusApiClient(CorpusFetchable):
         query = """
             query ScheduledSurface($scheduledSurfaceId: ID!, $date_today: Date!, $date_yesterday: Date!) {
               scheduledSurface(id: $scheduledSurfaceId) {
-                items_today:     items(date: $date_today)     { corpusItem { id topic publisher } scheduledDate }
-                items_yesterday: items(date: $date_yesterday) { corpusItem { id topic publisher } scheduledDate }
+                items_today:     items(date: $date_today)     { corpusItem { id topic publisher url } scheduledDate }
+                items_yesterday: items(date: $date_yesterday) { corpusItem { id topic publisher url } scheduledDate }
               }
             }
         """

--- a/app/data_providers/slate_providers/new_tab_slate_provider.py
+++ b/app/data_providers/slate_providers/new_tab_slate_provider.py
@@ -10,7 +10,7 @@ from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_recommendation_model import CorpusRecommendationModel
 from app.models.corpus_slate_lineup_model import RecommendationSurfaceId
 from app.models.localemodel import LocaleModel
-from app.rankers.algorithms import thompson_sampling, spread_publishers
+from app.rankers.algorithms import thompson_sampling, spread_publishers, boost_syndicated
 
 # Maximum tileId that Firefox can support. Firefox uses Javascript to store this value. The max value of a Javascript
 # number can be found using `Number.MAX_SAFE_INTEGER`. which is 2^53 - 1 because it uses a 64-bit IEEE 754 float.
@@ -108,5 +108,8 @@ class NewTabSlateProvider(SlateProvider):
         # 1. Primary sort order is publisher diversity. Sort is stable, so it will preserve recency order, except
         #    for duplicate publishers.
         items = spread_publishers(items, spread_distance=PUBLISHER_SPREAD_DISTANCE)
+
+        # Final step is to boost a syndicated article (if one exists).
+        items = boost_syndicated(items, metrics)
 
         return items

--- a/app/models/corpus_item_model.py
+++ b/app/models/corpus_item_model.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from typing import Optional
 
@@ -8,6 +9,7 @@ class CorpusItemModel(BaseModel):
     id: str
     topic: str = None
     publisher: str = None
+    url: str = None
 
     ranked_with_engagement_updated_at: Optional[datetime] = Field(
         default=None,
@@ -15,3 +17,11 @@ class CorpusItemModel(BaseModel):
                     ' indicates the recency of the engagement data, enabling us to monitor the delay in our engagement'
                     ' feedback loop. If engagement data was not utilized for ranking, this value will be null.'
     )
+
+    @property
+    def is_syndicated(self) -> Optional[bool]:
+        """
+        :return: True if item is syndicated, False if not syndicated, or None if unknown because url is not available.
+        """
+        if self.url is not None:
+            return re.search(r'^(https?://)?(www\.)?(get)?pocket\.com/explore/item', self.url) is not None

--- a/tests/assets/engagement_metrics.py
+++ b/tests/assets/engagement_metrics.py
@@ -1,5 +1,8 @@
+import datetime
 from typing import Dict, List
 
+from app.models.corpus_item_model import CorpusItemModel
+from app.models.metrics.corpus_item_engagement_model import CorpusItemEngagementModel
 from app.models.metrics.firefox_new_tab_metrics_model import FirefoxNewTabMetricsModel
 from app.models.metrics.metrics_model import MetricsModel
 
@@ -109,3 +112,30 @@ def generate_firefox_metrics(recommendation_ids: List[str]) -> Dict[str, 'Firefo
         metrics.update(_get_firefox_new_tab_metrics_model_dict(**kwargs))
 
     return metrics
+
+
+def generate_corpus_engagement(recommendations: List[CorpusItemModel]) -> Dict[str, 'CorpusItemEngagementModel']:
+    """
+    :return: Dictionary where keys are recommendation ids, and values are CorpusItemEngagementModel, with
+             - trailing_1_day_opens equal to 33 * (i + 1), for the i'th recommendation
+             - trailing_1_day_impressions being equal to 999
+    """
+    return {
+        rec.id: CorpusItemEngagementModel(
+            key=f'NEW_TAB_EN_US/edc5571f-7adb-537a-afd8-5612155d54da/{rec.id}',
+            recommendation_surface_id='NEW_TAB_EN_US',
+            corpus_slate_configuration_id='edc5571f-7adb-537a-afd8-5612155d54da',
+            corpus_item_id=rec.id,
+            trailing_1_day_opens=33 * (index + 1),  # 33, 66, 99, etc.
+            trailing_1_day_impressions=999,
+            trailing_7_day_opens=0,
+            trailing_7_day_impressions=0,
+            trailing_14_day_opens=0,
+            trailing_14_day_impressions=0,
+            trailing_21_day_opens=0,
+            trailing_21_day_impressions=0,
+            trailing_28_day_opens=0,
+            trailing_28_day_impressions=0,
+            updated_at=datetime.datetime.now(),
+        ) for index, rec in enumerate(recommendations)
+    }

--- a/tests/unit/models/test_corpus_item_model.py
+++ b/tests/unit/models/test_corpus_item_model.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.models.corpus_item_model import CorpusItemModel
+from tests.assets.topics import business_topic
+
+
+@pytest.mark.parametrize(('url', 'is_syndicated'), [
+    ('https://getpocket.com/explore/item/8-natural-ways-to-repel-insects-without-bug-spray', True),
+    ('http://getpocket.com/explore/item/8-natural-ways-to-repel-insects-without-bug-spray', True),
+    ('https://www.getpocket.com/explore/item/8-natural-ways-to-repel-insects-without-bug-spray', True),
+    ('https://pocket.com/explore/item/8-natural-ways-to-repel-insects-without-bug-spray', True),  # pocket.com redirect
+    ('https://getpocket.com/explore/item/the-secrets-of-real-life-wedding-crashers?utm_source=pocket-newtab', True),
+    ('https://getpocket.com/collections/the-unexpected-flavor-combos-too-delicious-not-to-try', False),  # collection
+    ('https://getpocket.com/explore/entertainment', False),  # topic page
+    ('https://www.harpersbazaar.com/beauty/hair/a44284121/hair-braiders-harlem-injuries-protections/', False),
+    ('https://example.com/?utm_content=https://www.getpocket.com/explore/item/example', False),
+    (None, None),
+])
+def test_corpus_item_model_is_syndicated(url, is_syndicated):
+    corpus_item = CorpusItemModel(
+        id='rec-123',
+        topic=business_topic.corpus_topic_id,
+        publisher='The Original Publisher',
+        url=url,
+    )
+
+    assert corpus_item.is_syndicated == is_syndicated


### PR DESCRIPTION
# Goal
Replicate existing functionality from feed-machine to [boost syndicated articles](https://github.com/Pocket/feed-machine/blob/master/ranker.py#L143-L187) on NewTab.

## Reference

- [Jira ticket DIS-845](https://getpocket.atlassian.net/browse/DIS-845)

- [Original project description and experiment results](https://docs.google.com/document/d/1Vgq63DZQF-pz7R3kvcNXgkUd1I829FZqkIUlpIVY_g4)
- [feed-machine implementation](https://github.com/Pocket/feed-machine/blob/master/ranker.py#L143-L187)

## Implementation Decisions
- The feed-machine implementation supported multiple slots, and different ways to select the syndicated article to be boosted. I simplified the code to a single slot, and the highest CTR item, because that's what we've used for the last few years.