### PR TITLE
fix(NewTab): [MC-76] Content should roll over at 3am local time

### DIFF
--- a/app/data_providers/corpus/corpus_api_client.py
+++ b/app/data_providers/corpus/corpus_api_client.py
@@ -35,7 +35,9 @@ class CorpusApiClient(CorpusFetchable):
             }
         """
 
-        # The date is supposed to progress at 3am local time
+        # The date is supposed to progress at 3am local time, where 'local time' is based on the timezone associated
+        # with the scheduled surface. This requirement is documented in the NewTab slate spec:
+        # https://getpocket.atlassian.net/wiki/spaces/PE/pages/2927100008/Fx+NewTab+Slate+spec
         today = datetime.now(tz=self.get_surface_timezone(scheduled_surface_id)) - timedelta(hours=3)
         yesterday = today - timedelta(days=1)
 
@@ -79,11 +81,13 @@ class CorpusApiClient(CorpusFetchable):
 
     @staticmethod
     def get_surface_timezone(scheduled_surface_id: str) -> pytz.timezone:
-        # TODO: Modify curated-corpus-api to get timezone from query. Timezones are already hardcoded there.
+        # TODO: Add a query to curated-corpus-api to get timezone by scheduled surface, and stop hardcoding them here.
+        # For a list of all scheduled surfaces and their corresponding timezone, see:
+        # https://getpocket.atlassian.net/wiki/spaces/PE/pages/2584150049/Pocket+Shared+Data#Source-of-Truth.5
         zones = {
             'NEW_TAB_EN_US': 'America/New_York',
             'NEW_TAB_EN_GB': 'Europe/London',
-            'NEW_TAB_EN_INTL': 'Asia/Kolkata',
+            'NEW_TAB_EN_INTL': 'Asia/Kolkata',  # Note: en-Intl is poorly named. Only India is currently eligible.
             'NEW_TAB_DE_DE': 'Europe/Berlin',
             'NEW_TAB_ES_ES': 'Europe/Madrid',
             'NEW_TAB_FR_FR': 'Europe/Paris',

--- a/app/data_providers/corpus/corpus_api_client.py
+++ b/app/data_providers/corpus/corpus_api_client.py
@@ -35,8 +35,8 @@ class CorpusApiClient(CorpusFetchable):
             }
         """
 
-        # The date is supposed to progress at midnight CET (Central European Time).
-        today = datetime.now(tz=self.get_surface_timezone(scheduled_surface_id))
+        # The date is supposed to progress at 3am local time
+        today = datetime.now(tz=self.get_surface_timezone(scheduled_surface_id)) - timedelta(hours=3)
         yesterday = today - timedelta(days=1)
 
         body = {


### PR DESCRIPTION
# Goal
New Tab content should roll over at 3am local time, based on the timezone associated with the NewTab recommendation surface.

In the previous implementation, it incorrectly rolled over at midnight local time. This bug was introduced when migrating from the feed-machine to recommendation-api. Before the migration, content rolled over at 3am local time, as expected.

## Reference

I added to the Firefox NewTab slate spec:
> Content rolls over at 3am local time.
* https://getpocket.atlassian.net/wiki/spaces/PE/pages/2927100008/Fx+NewTab+Slate+spec

Tickets:
* https://mozilla-hub.atlassian.net/jira/software/c/projects/MC/boards/720?modal=detail&selectedIssue=MC-76&assignee=64065e8893cf2599462fe21d

Slack thread:
> Carolyn: The stories you schedule for each day in the Curation Tool will start hitting New Tab at 3am in your New Tab’s local timezone. (For U.S. New Tab that means 3am EST).
* https://mozilla.slack.com/archives/C05EVRU1U1X/p1694016926870279

## Implementation Decisions
- In the test, I made the frozen time a parameter in the test, such that it can be precisely set to just before and after the publishing day is supposed to roll over. That's less confusing and more precise.