### PR TITLE
fix(unleash): making unleash session sticky

### DIFF
--- a/app/data_providers/unleash_provider.py
+++ b/app/data_providers/unleash_provider.py
@@ -95,6 +95,9 @@ class UnleashProvider:
                 # not related to recit anymore, but it's what the unleash strategy hasUserModel expects
                 body['variables']['context']['properties']['recItUserProfile'] = {'userModels': user.user_models}
 
+        if user is not None and user.hashed_guid is not None:
+            body['variables']['context']['sessionId'] = user.hashed_guid
+
         async with self.pocket_graph_client_session.post(url='/', json=body, raise_for_status=True) as resp:
             response_json = await resp.json()
             assignments_data = response_json['data']['unleashAssignments']['assignments']

--- a/tests/functional/data_providers/test_unleash_provider.py
+++ b/tests/functional/data_providers/test_unleash_provider.py
@@ -26,6 +26,7 @@ async def test_get_assignments(pocket_graph_server: TestServer, user_1: RequestU
         'appName': unleash_config.APP_NAME,
         'environment': unleash_config.ENVIRONMENT,
         'userId': user_1.hashed_user_id,
+        'sessionId': user_1.hashed_guid,
         'properties': {'locale': user_1.locale}
     }
 
@@ -69,6 +70,7 @@ async def test_get_assignments_no_user_id(pocket_graph_server: TestServer, user_
     assert request_json['variables']['context'] == {
         'appName': unleash_config.APP_NAME,
         'environment': unleash_config.ENVIRONMENT,
+        'sessionId': user_1.hashed_guid,
     }
 
     # pocket_graph_server returns data from `tests/assets/json/unleash_assignments.json`


### PR DESCRIPTION
# Goal

When doing a gradual rollout we want to ensure that we have something we can be "sticky" against for a user.  Usually this is the userId, but if there is no user Id we need to use the sessionId or `guid`

