### PR TITLE
feat(thompson-sampling): ensure thompson sampling is persistent based on user and day

### DIFF
--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -210,13 +210,13 @@ class HomeDispatch:
         slates = []
         if home_v3_assignment is not None and home_v3_assignment.assigned is True:
             slates = [
-                self.pocket_worthy_provider.get_slate(seed_id=seed_id),
+                self.pocket_worthy_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
                 self.pocket_hits_slate_provider.get_slate(),
                 self.get_for_you_or_recommended_reads(preferred_topics=preferred_topics,
                                                       user_impression_capped_list=user_impression_capped_list,
                                                       seed_id=seed_id
                                                       ),
-                self.life_hacks_slate_provider.get_slate(seed_id=seed_id),
+                self.life_hacks_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
             ]
         else:
             slates = [
@@ -225,8 +225,8 @@ class HomeDispatch:
                                                       seed_id=seed_id
                                                       ),
                 self.pocket_hits_slate_provider.get_slate(),
-                self.collection_slate_provider.get_slate(seed_id=seed_id),
-                self.life_hacks_slate_provider.get_slate(seed_id=seed_id),
+                self.collection_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
+                self.life_hacks_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
             ]
             slates += await self._get_topic_slate_promises(preferred_topics=preferred_topics, default=DEFAULT_TOPICS)
 
@@ -250,10 +250,10 @@ class HomeDispatch:
             return await self.for_you_slate_provider.get_slate(
                 preferred_topics=preferred_topics,
                 user_impression_capped_list=user_impression_capped_list,
-                seed_id=seed_id
+                enable_thompson_sampling_with_seed=seed_id
             )
         else:
-            return await self.recommended_reads_slate_provider.get_slate(seed_id=seed_id)
+            return await self.recommended_reads_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id)
 
     async def get_de_de_slate_lineup(self, user: RequestUser, recommendation_count: int, locale: LocaleModel) -> \
             Tuple[CorpusSlateLineupModel, Optional[UnleashAssignmentModel]]:
@@ -277,14 +277,14 @@ class HomeDispatch:
         assignment = await self.unleash_provider.get_assignment(POCKET_HOME_V3_FEATURE_FLAG, user=user)
         if assignment is not None and assignment.assigned is True:
             slates = [
-                self.collection_slate_provider.get_slate(seed_id=seed_id),
-                self.recommended_reads_slate_provider.get_slate(seed_id=seed_id),
+                self.collection_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
+                self.recommended_reads_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
             ]
             slates += await self._get_topic_slate_promises(preferred_topics=[], default=GERMAN_HOME_TOPICS)
         else:
             slates = [
-                self.recommended_reads_slate_provider.get_slate(seed_id=seed_id),
-                self.collection_slate_provider.get_slate(seed_id=seed_id),
+                self.recommended_reads_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
+                self.collection_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id),
             ]
             slates += await self._get_topic_slate_promises(preferred_topics=[], default=GERMAN_HOME_TOPICS)
 

--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -32,7 +32,7 @@ class CollectionSlateProvider(HomeSlateProvider):
             **kwargs,
     ) -> List[CorpusItemModel]:
 
-        if kwargs.get('enable_thompson_sampling'):
+        if kwargs.get('seed_id'):
             """
             :param items: Candidate corpus items
             :return: Ranks items based on Thompson sampling.
@@ -43,6 +43,7 @@ class CollectionSlateProvider(HomeSlateProvider):
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
+                random_state=kwargs['seed_id'],
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
                 default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
                 default_beta_prior=1200)  # 20% of average daily item impressions for this slate

--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -32,7 +32,7 @@ class CollectionSlateProvider(HomeSlateProvider):
             **kwargs,
     ) -> List[CorpusItemModel]:
 
-        if kwargs.get('seed_id'):
+        if kwargs.get('enable_thompson_sampling_with_seed'):
             """
             :param items: Candidate corpus items
             :return: Ranks items based on Thompson sampling.
@@ -43,7 +43,7 @@ class CollectionSlateProvider(HomeSlateProvider):
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
-                random_state=kwargs['seed_id'],
+                random_state=kwargs['enable_thompson_sampling_with_seed'],
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
                 default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
                 default_beta_prior=1200)  # 20% of average daily item impressions for this slate

--- a/app/data_providers/slate_providers/for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/for_you_slate_provider.py
@@ -42,13 +42,13 @@ class ForYouSlateProvider(HomeSlateProvider):
         assert preferred_topics is not None
         assert user_impression_capped_list is not None
 
-        if kwargs.get('seed_id'):
+        if kwargs.get('enable_thompson_sampling_with_seed'):
             metrics = await self.corpus_engagement_provider.get(
                 self.recommendation_surface_id, self.configuration_id, items)
 
             items = thompson_sampling(
                 recs=items,
-                random_state=kwargs['seed_id'],
+                random_state=kwargs['enable_thompson_sampling_with_seed'],
                 metrics=metrics,
                 trailing_period=14,  # A long period might work better given that some topics get few impressions
                 default_alpha_prior=20,  # beta * P95 item CTR for this slate (1.6%)

--- a/app/data_providers/slate_providers/for_you_slate_provider.py
+++ b/app/data_providers/slate_providers/for_you_slate_provider.py
@@ -42,12 +42,13 @@ class ForYouSlateProvider(HomeSlateProvider):
         assert preferred_topics is not None
         assert user_impression_capped_list is not None
 
-        if kwargs.get('enable_thompson_sampling'):
+        if kwargs.get('seed_id'):
             metrics = await self.corpus_engagement_provider.get(
                 self.recommendation_surface_id, self.configuration_id, items)
 
             items = thompson_sampling(
                 recs=items,
+                random_state=kwargs['seed_id'],
                 metrics=metrics,
                 trailing_period=14,  # A long period might work better given that some topics get few impressions
                 default_alpha_prior=20,  # beta * P95 item CTR for this slate (1.6%)

--- a/app/data_providers/slate_providers/life_hacks_slate_provider.py
+++ b/app/data_providers/slate_providers/life_hacks_slate_provider.py
@@ -18,7 +18,7 @@ class LifeHacksSlateProvider(HomeSlateProvider):
             **kwargs,
     ) -> List[CorpusItemModel]:
 
-        if kwargs.get('seed_id'):
+        if kwargs.get('enable_thompson_sampling_with_seed'):
             """
             :param items: Candidate corpus items
             :return: Ranks items based on Thompson sampling.
@@ -29,9 +29,9 @@ class LifeHacksSlateProvider(HomeSlateProvider):
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
-                random_state=kwargs['seed_id'],
+                random_state=kwargs['enable_thompson_sampling_with_seed'],
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
-                default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
-                default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+                default_alpha_prior=18,   # copied from CollectionSlateProvider
+                default_beta_prior=1200)  # copied from CollectionSlateProvider
 
         return items

--- a/app/data_providers/slate_providers/life_hacks_slate_provider.py
+++ b/app/data_providers/slate_providers/life_hacks_slate_provider.py
@@ -1,4 +1,8 @@
+from typing import List
+
 from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
+from app.models.corpus_item_model import CorpusItemModel
+from app.rankers.algorithms import thompson_sampling
 
 
 class LifeHacksSlateProvider(HomeSlateProvider):
@@ -6,3 +10,28 @@ class LifeHacksSlateProvider(HomeSlateProvider):
     @property
     def candidate_set_id(self) -> str:
         return 'da9cb7a1-3a34-4211-b918-73819a5586c8'
+
+    async def rank_corpus_items(
+            self,
+            items: List[CorpusItemModel],
+            *args,
+            **kwargs,
+    ) -> List[CorpusItemModel]:
+
+        if kwargs.get('seed_id'):
+            """
+            :param items: Candidate corpus items
+            :return: Ranks items based on Thompson sampling.
+            """
+            metrics = await self.corpus_engagement_provider.get(
+                self.recommendation_surface_id, self.configuration_id, items)
+
+            items = thompson_sampling(
+                recs=items,
+                metrics=metrics,
+                random_state=kwargs['seed_id'],
+                trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
+                default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
+                default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+
+        return items

--- a/app/data_providers/slate_providers/pockety_worthy_provider.py
+++ b/app/data_providers/slate_providers/pockety_worthy_provider.py
@@ -1,4 +1,8 @@
+from typing import List
+
 from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
+from app.models.corpus_item_model import CorpusItemModel
+from app.rankers.algorithms import thompson_sampling
 
 
 class PocketWorthyProvider(HomeSlateProvider):
@@ -6,3 +10,28 @@ class PocketWorthyProvider(HomeSlateProvider):
     @property
     def candidate_set_id(self) -> str:
         return '0e0a8663-a2c1-430e-9b8c-3a5b6d9eda11'
+
+    async def rank_corpus_items(
+            self,
+            items: List[CorpusItemModel],
+            *args,
+            **kwargs,
+    ) -> List[CorpusItemModel]:
+
+        if kwargs.get('seed_id'):
+            """
+            :param items: Candidate corpus items
+            :return: Ranks items based on Thompson sampling.
+            """
+            metrics = await self.corpus_engagement_provider.get(
+                self.recommendation_surface_id, self.configuration_id, items)
+
+            items = thompson_sampling(
+                recs=items,
+                metrics=metrics,
+                random_state=kwargs['seed_id'],
+                trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
+                default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
+                default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+
+        return items

--- a/app/data_providers/slate_providers/pockety_worthy_provider.py
+++ b/app/data_providers/slate_providers/pockety_worthy_provider.py
@@ -18,7 +18,7 @@ class PocketWorthyProvider(HomeSlateProvider):
             **kwargs,
     ) -> List[CorpusItemModel]:
 
-        if kwargs.get('seed_id'):
+        if kwargs.get('enable_thompson_sampling_with_seed'):
             """
             :param items: Candidate corpus items
             :return: Ranks items based on Thompson sampling.
@@ -29,9 +29,9 @@ class PocketWorthyProvider(HomeSlateProvider):
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
-                random_state=kwargs['seed_id'],
+                random_state=kwargs['enable_thompson_sampling_with_seed'],
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
-                default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
-                default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+                default_alpha_prior=18,   # copied from CollectionSlateProvider
+                default_beta_prior=1200)  # copied from CollectionSlateProvider
 
         return items

--- a/app/data_providers/slate_providers/recommended_reads_slate_provider.py
+++ b/app/data_providers/slate_providers/recommended_reads_slate_provider.py
@@ -28,14 +28,14 @@ class RecommendedReadsSlateProvider(HomeSlateProvider):
         :param items: Candidate corpus items
         :return: Ranks items based on Thompson sampling.
         """
-        if kwargs.get('seed_id'):
+        if kwargs.get('enable_thompson_sampling_with_seed'):
             metrics = await self.corpus_engagement_provider.get(
                 self.recommendation_surface_id, self.configuration_id, items)
 
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
-                random_state=kwargs['seed_id'],
+                random_state=kwargs['enable_thompson_sampling_with_seed'],
                 trailing_period=7,  # With few new items/day and relatively many impressions, a low period is sufficient
                 default_alpha_prior=12,   # beta * P95 item CTR for this slate (0.7%)
                 default_beta_prior=1700)  # 5% of average daily item impressions for this slate

--- a/app/data_providers/slate_providers/recommended_reads_slate_provider.py
+++ b/app/data_providers/slate_providers/recommended_reads_slate_provider.py
@@ -28,13 +28,14 @@ class RecommendedReadsSlateProvider(HomeSlateProvider):
         :param items: Candidate corpus items
         :return: Ranks items based on Thompson sampling.
         """
-        if kwargs.get('enable_thompson_sampling'):
+        if kwargs.get('seed_id'):
             metrics = await self.corpus_engagement_provider.get(
                 self.recommendation_surface_id, self.configuration_id, items)
 
             items = thompson_sampling(
                 recs=items,
                 metrics=metrics,
+                random_state=kwargs['seed_id'],
                 trailing_period=7,  # With few new items/day and relatively many impressions, a low period is sufficient
                 default_alpha_prior=12,   # beta * P95 item CTR for this slate (0.7%)
                 default_beta_prior=1700)  # 5% of average daily item impressions for this slate

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -98,7 +98,6 @@ def thompson_sampling(
 
     opens_column = f"trailing_{trailing_period}_day_opens"
     imprs_column = f"trailing_{trailing_period}_day_impressions"
-
     if any(not (hasattr(m, opens_column) and hasattr(m, opens_column)) for m in metrics.values()):
         raise ValueError(f"Missing attribute {opens_column} or {imprs_column} on some metrics: {metrics.values()}")
 

--- a/app/rankers/algorithms.py
+++ b/app/rankers/algorithms.py
@@ -69,7 +69,9 @@ def thompson_sampling(
         metrics: Dict[(int or str), Union['MetricsModel', 'CorpusItemEngagementModel']],
         trailing_period: int = 28,
         default_alpha_prior=DEFAULT_ALPHA_PRIOR,
-        default_beta_prior=DEFAULT_BETA_PRIOR) -> RankableListType:
+        default_beta_prior=DEFAULT_BETA_PRIOR,
+        random_state: int = None,
+) -> RankableListType:
     """
     Re-rank items using Thompson sampling which combines exploitation of known item CTR
     with exploration of new items with unknown CTR modeled by a prior
@@ -81,6 +83,12 @@ def thompson_sampling(
     :param recs: a list of recommendations in the desired order (pre-publisher spread)
     :param metrics: a dict with item_id as key and dynamodb row modeled as ClickDataModel
     :param trailing_period: the number of days that impressions and opens are aggregated for sampling
+    :param random_state: (optional) Random seed used to initialize the pseudo-random number generator.
+      Can be any integer between 0 and 2**32 - 1 inclusive. This can be used to give a user a consistent
+      experience for a set period of time, by hashing the user id and date into a 32-bit integer:
+      ```python
+      random_seed = integer_hash(f"{user_id}{current_date}", 0, 2**32)
+      ```
     :return: a re-ordered version of recs satisfying the spread as best as possible
     """
 
@@ -123,13 +131,13 @@ def thompson_sampling(
             # posterior combines click data with prior (also a beta distribution)
             no_opens = max(imprs_metric - open_metric + beta_prior, 1e-18)
             # sample from posterior for CTR given click data
-            score = beta.rvs(opens, no_opens)
+            score = beta.rvs(opens, no_opens, random_state=random_state)
             scores.append((rec, score))
 
             if hasattr(rec, 'ranked_with_engagement_updated_at') and hasattr(metrics_model, 'updated_at'):
                 rec.ranked_with_engagement_updated_at = metrics_model.updated_at
         else:  # no click data, sample from module prior
-            scores.append((rec, prior.rvs()))
+            scores.append((rec, prior.rvs(random_state=random_state)))
 
     scores.sort(key=itemgetter(1), reverse=True)
     return [x[0] for x in scores]

--- a/tests/unit/data_providers/test_for_you_slate_provider.py
+++ b/tests/unit/data_providers/test_for_you_slate_provider.py
@@ -122,8 +122,8 @@ class TestForYouSlateProvider:
             assert set(r.id for r in ranked_items[:len(preferred_topic_items)]) == set(
                 r.id for r in preferred_topic_items)
 
-        # Assert that the same item is not always ranked at the top.
-        assert len(top_ranked_item_ids) > 1
+        # Assert that the same item is always ranked at the top for the same user.
+        assert len(top_ranked_item_ids) == 1
 
     async def test_no_thompson_sampling(self, for_you_slate_provider):
         items = [CorpusItemModel(id=str(i), topic=all_topic_fixtures[i % 2].corpus_topic_id) for i in range(10)]

--- a/tests/unit/rankers/test_algorithms.py
+++ b/tests/unit/rankers/test_algorithms.py
@@ -256,9 +256,9 @@ class TestAlgorithmsThompsonSampling:
 
     @pytest.mark.parametrize("thompson_sampling_function,metrics", [
         (thompson_sampling, generate_metrics(28)),  # 28 day is the default
-        # (thompson_sampling_1day, generate_metrics(1)),
-        # (thompson_sampling_7day, generate_metrics(7)),
-        # (thompson_sampling_14day, generate_metrics(14)),
+        (thompson_sampling_1day, generate_metrics(1)),
+        (thompson_sampling_7day, generate_metrics(7)),
+        (thompson_sampling_14day, generate_metrics(14)),
     ])
     def test_rank_by_ctr_over_n_trials(self, thompson_sampling_function, metrics, ntrials = 99):
         """
@@ -284,7 +284,7 @@ class TestAlgorithmsThompsonSampling:
 
         for rec in recs:
             # compute average positional rank over the trials
-            ranks[rec.item.item_id] = ranks.get(rec.item.item_id, 0) / 99
+            ranks[rec.item.item_id] = ranks.get(rec.item.item_id, 0) / ntrials
 
         final_ranks = sorted(ranks.items(), key=itemgetter(1))
 
@@ -330,7 +330,7 @@ class TestAlgorithmsThompsonSampling:
 
         for rec in recs:
             # compute average positional rank over the trials
-            ranks[rec.item.item_id] = ranks.get(rec.item.item_id, 0) / 99
+            ranks[rec.item.item_id] = ranks.get(rec.item.item_id, 0) / ntrials
 
         final_ranks = sorted(ranks.items(), key=itemgetter(1))
 

--- a/tests/unit/rankers/test_algorithms.py
+++ b/tests/unit/rankers/test_algorithms.py
@@ -256,9 +256,9 @@ class TestAlgorithmsThompsonSampling:
 
     @pytest.mark.parametrize("thompson_sampling_function,metrics", [
         (thompson_sampling, generate_metrics(28)),  # 28 day is the default
-        (thompson_sampling_1day, generate_metrics(1)),
-        (thompson_sampling_7day, generate_metrics(7)),
-        (thompson_sampling_14day, generate_metrics(14)),
+        # (thompson_sampling_1day, generate_metrics(1)),
+        # (thompson_sampling_7day, generate_metrics(7)),
+        # (thompson_sampling_14day, generate_metrics(14)),
     ])
     def test_rank_by_ctr_over_n_trials(self, thompson_sampling_function, metrics, ntrials = 99):
         """


### PR DESCRIPTION
# Goal

Ensure that for every request we apply thompson sampling but ensure that the content is the same for each user instead of constantly changing on page load.

## Todos
- [x] @mmiermans to add seed function
- [x] @bassrock to pair with @mmiermans on adding it to the slate providers
