### PR TITLE
feat(capping): adding impression capping for each slate that supports it

### DIFF
--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -4,7 +4,7 @@ from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.link import LinkModel
 from app.models.localemodel import LocaleModel
-from app.rankers.algorithms import thompson_sampling
+from app.rankers.algorithms import thompson_sampling, rank_by_impression_caps
 from app.config import POCKET_HOME_V3_FEATURE_FLAG
 
 
@@ -28,6 +28,7 @@ class CollectionSlateProvider(HomeSlateProvider):
     async def rank_corpus_items(
             self,
             items: List[CorpusItemModel],
+            user_impression_capped_list: List[CorpusItemModel] = None,
             *args,
             **kwargs,
     ) -> List[CorpusItemModel]:
@@ -47,5 +48,8 @@ class CollectionSlateProvider(HomeSlateProvider):
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
                 default_alpha_prior=18,   # beta * P95 item CTR for this slate (1.5%)
                 default_beta_prior=1200)  # 20% of average daily item impressions for this slate
+
+        if user_impression_capped_list is not None:
+            items = rank_by_impression_caps(items, user_impression_capped_list)
 
         return items

--- a/app/data_providers/slate_providers/life_hacks_slate_provider.py
+++ b/app/data_providers/slate_providers/life_hacks_slate_provider.py
@@ -2,7 +2,7 @@ from typing import List
 
 from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
-from app.rankers.algorithms import thompson_sampling
+from app.rankers.algorithms import thompson_sampling, rank_by_impression_caps
 
 
 class LifeHacksSlateProvider(HomeSlateProvider):
@@ -14,6 +14,7 @@ class LifeHacksSlateProvider(HomeSlateProvider):
     async def rank_corpus_items(
             self,
             items: List[CorpusItemModel],
+            user_impression_capped_list: List[CorpusItemModel] = None,
             *args,
             **kwargs,
     ) -> List[CorpusItemModel]:
@@ -33,5 +34,8 @@ class LifeHacksSlateProvider(HomeSlateProvider):
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
                 default_alpha_prior=18,   # copied from CollectionSlateProvider
                 default_beta_prior=1200)  # copied from CollectionSlateProvider
+
+        if user_impression_capped_list is not None:
+            items = rank_by_impression_caps(items, user_impression_capped_list)
 
         return items

--- a/app/data_providers/slate_providers/pockety_worthy_provider.py
+++ b/app/data_providers/slate_providers/pockety_worthy_provider.py
@@ -2,7 +2,7 @@ from typing import List
 
 from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
-from app.rankers.algorithms import thompson_sampling
+from app.rankers.algorithms import thompson_sampling, rank_by_impression_caps
 
 
 class PocketWorthyProvider(HomeSlateProvider):
@@ -14,6 +14,7 @@ class PocketWorthyProvider(HomeSlateProvider):
     async def rank_corpus_items(
             self,
             items: List[CorpusItemModel],
+            user_impression_capped_list: List[CorpusItemModel] = None,
             *args,
             **kwargs,
     ) -> List[CorpusItemModel]:
@@ -33,5 +34,8 @@ class PocketWorthyProvider(HomeSlateProvider):
                 trailing_period=14,  # With a low impression volume, a longer period should help find the best stories
                 default_alpha_prior=18,   # copied from CollectionSlateProvider
                 default_beta_prior=1200)  # copied from CollectionSlateProvider
+
+        if user_impression_capped_list is not None:
+            items = rank_by_impression_caps(items, user_impression_capped_list)
 
         return items

--- a/app/data_providers/slate_providers/recommended_reads_slate_provider.py
+++ b/app/data_providers/slate_providers/recommended_reads_slate_provider.py
@@ -1,10 +1,9 @@
 from typing import List
 
-from app.config import POCKET_HOME_V3_FEATURE_FLAG
 from app.data_providers.slate_providers.slate_provider import HomeSlateProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.localemodel import LocaleModel
-from app.rankers.algorithms import thompson_sampling
+from app.rankers.algorithms import thompson_sampling, rank_by_impression_caps
 
 
 class RecommendedReadsSlateProvider(HomeSlateProvider):
@@ -21,6 +20,7 @@ class RecommendedReadsSlateProvider(HomeSlateProvider):
     async def rank_corpus_items(
             self,
             items: List[CorpusItemModel],
+            user_impression_capped_list: List[CorpusItemModel] = None,
             *args,
             **kwargs,
     ) -> List[CorpusItemModel]:
@@ -39,5 +39,8 @@ class RecommendedReadsSlateProvider(HomeSlateProvider):
                 trailing_period=7,  # With few new items/day and relatively many impressions, a low period is sufficient
                 default_alpha_prior=12,   # beta * P95 item CTR for this slate (0.7%)
                 default_beta_prior=1700)  # 5% of average daily item impressions for this slate
+
+        if user_impression_capped_list is not None:
+            items = rank_by_impression_caps(items, user_impression_capped_list)
 
         return items


### PR DESCRIPTION
# Goal

I noticed home was not showing completely new content. Digging in I realized only the for you slate actually had user impression capping on.

## Todos
- [x] Add impression capping if we have a user object
