### PR TITLE
feat: [MC-1035] newTabSlate accepts enableRankingByRegion

### DIFF
--- a/app/graphql/resolvers/corpus_slate_resolvers.py
+++ b/app/graphql/resolvers/corpus_slate_resolvers.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import strawberry
@@ -31,8 +32,18 @@ async def resolve_new_tab_slate(
             description="The geographic region, for example 'FR' or 'IT', or null if unavailable. This is currently not"
                         " used, but will be used in the future to decide which scheduled surface to return when we"
                         " serve multiple markets with the same language.")],
+        enable_ranking_by_region: Annotated[Optional[bool], strawberry.argument(
+            description="Experimental parameter that when enabled, adjusts the ranking of items based on the region."
+                        " By default this is off. Firefox Desktop will enable it by setting the pref "
+                        " browser.newtabpage.activity-stream.discoverystream.pocket-feed-parameters to \"&enableRankingByRegion=1\""
+                        " for the treatment branch of a Nimbus experiment."
+        )] = False,
 ) -> CorpusSlate:
     di = DiContainer.get()
+    if enable_ranking_by_region:
+        # Log a message to indicate region-specific ranking is enabled.
+        # The region-specific ranker will be implemented in MC-1036.
+        logging.info(f"Results will soon be ranked for the {region} region")
 
     async with PocketGraphClientSession(CorpusApiGraphConfig()) as graph_client_session:
         slate_model = await NewTabDispatch(


### PR DESCRIPTION
# Goal
Allow `enableRankingByRegion` to be passed in to the `newTabSlate` query.

In a future PR we will optimize the recommendation order for the given region if this is set to True.

## Reference

Tickets:
* [MC-1035](https://mozilla-hub.atlassian.net/browse/MC-1035)

Doc:
* [Experiment doc](https://docs.google.com/document/d/14SfGmWPwnzWv7oeDsHXZuRT-EUISEGqXCQmHRaoP6Lg/edit)

## Apollo change

![image](https://github.com/Pocket/recommendation-api/assets/1547251/8c1d5973-f773-4435-891d-8b390fbc6919)

## Implementation Decisions
- I added a log message so we can check when this is successfully passed in once the change in firefox-api-proxy is merged.

[MC-1035]: https://mozilla-hub.atlassian.net/browse/MC-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ