### PR TITLE
fix: [MC-1182] disable failing snowplow health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       memcached:
         condition: service_started
       snowplow:
-        condition: service_healthy  # snowplow needs to be healthy before tests can start.
+        condition: service_started
       qdrant:
         condition: service_started
 
@@ -57,12 +57,6 @@ services:
     platform: linux/amd64
     ports:
       - '9090:9090'
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:9090/micro/all"]
-      interval: 5s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
 
   qdrant:
    image: qdrant/qdrant:v0.11.6


### PR DESCRIPTION

# Goal
[MC-1182](https://mozilla-hub.atlassian.net/browse/MC-1182) Make tests pass in CI again.

We switched to distroless snowplow in https://github.com/Pocket/Web/pull/4691. This version of Snowplow does not contain curl. The recommendation-api tests pass without this health check.

## Reference

* [Slack thread](https://mozilla.slack.com/archives/C05G12U8N1H/p1717525727108679?thread_ts=1717514337.257259&cid=C05G12U8N1H)

## Implementation Decisions
- recommendation-api is [the only service](https://github.com/search?q=org%3APocket+depends_on+snowplow&type=code) I could find that depends on a health check in snowplow micro. It's probably not necessary. If we do see failures in CI, we can decide to put the health check back and change the snowplow image back to the non-distroless version.

[MC-1182]: https://mozilla-hub.atlassian.net/browse/MC-1182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ