### PR TITLE
feat(syndication): removing syndication as a test

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,5 @@ GERMAN_HOME_TOPICS = [
     '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
 ]
 
-# Changes the slate lineups for home and removes thompson sampling for a new version of home
-POCKET_HOME_PRIDE_FEATURE_FLAG = 'temp.recommendation-api.pride'
-POCKET_HOME_V4_FEATURE_FLAG = 'temp.recommendation-api.pocket-home-v4'
+# Changes the slate lineups for home and removes syndication as a a/b test
+POCKET_HOME_NO_SYNDICATION_FEATURE_FLAG = 'temp.recommendation-api.pocket-home-no-syndication'

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -6,7 +6,8 @@ from asyncio import gather
 from typing import List, Coroutine, Any, Tuple, Optional
 from datetime import datetime
 
-from app.config import DEFAULT_TOPICS, GERMAN_HOME_TOPICS, POCKET_HOME_PRIDE_FEATURE_FLAG, POCKET_HOME_V4_FEATURE_FLAG
+from app.config import DEFAULT_TOPICS, GERMAN_HOME_TOPICS, \
+    POCKET_HOME_NO_SYNDICATION_FEATURE_FLAG
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.slate_providers.pockety_worthy_provider import PocketWorthyProvider
 from app.data_providers.slate_providers.pride_slate_provider import PrideSlateProvider
@@ -195,9 +196,11 @@ class HomeDispatch:
             4. 'Life Hacks' slate
         """
         user_impression_capped_list, \
-            preferred_topics = await gather(
+            preferred_topics, \
+            no_syndication_assignment = await gather(
             self.user_impression_cap_provider.get(user),
-            self._get_preferred_topics(user)
+            self._get_preferred_topics(user),
+            self.unleash_provider.get_assignment(POCKET_HOME_NO_SYNDICATION_FEATURE_FLAG, user=user),
         )
 
         seed_id = self.get_seed_id(user=user)
@@ -214,13 +217,15 @@ class HomeDispatch:
             self.life_hacks_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id,
                                                      user_impression_capped_list=user_impression_capped_list),
         ]
+        if no_syndication_assignment is not None and no_syndication_assignment.variant == 'treatment' is True:
+                del slates[0]
 
         return CorpusSlateLineupModel(
             slates=self._dedupe_and_limit(
                 slates=list(await gather(*slates)),
                 recommendation_count=recommendation_count,
             ),
-        ), None
+        ), no_syndication_assignment
 
     async def get_for_you_or_recommended_reads(self, preferred_topics: List[TopicModel],
                                                user_impression_capped_list: List[CorpusItemModel],
@@ -246,8 +251,8 @@ class HomeDispatch:
         :param recommendation_count:
         :param locale:
         :return: the Home slate lineup:
-                1. Recommended Reads
-                2. Collection slate
+                1. Collection slate
+                2. Recommended Reads
                 3. Topic slates according to defaults
         """
 

--- a/tests/unit/data_providers/test_for_you_slate_provider.py
+++ b/tests/unit/data_providers/test_for_you_slate_provider.py
@@ -2,14 +2,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from app.config import POCKET_HOME_V4_FEATURE_FLAG
 from app.data_providers.slate_providers.for_you_slate_provider import ForYouSlateProvider
-from app.data_providers.unleash_provider import UnleashProvider
 from app.models.corpus_item_model import CorpusItemModel
 from app.models.corpus_slate_lineup_model import RecommendationSurfaceId
 from app.models.localemodel import LocaleModel
 from app.models.recommendation_reason_type import RecommendationReasonType
-from app.models.unleash_assignment import UnleashAssignmentModel
 from tests.assets.topics import business_topic, all_topic_fixtures
 
 
@@ -25,15 +22,12 @@ def for_you_slate_provider(corpus_feature_group_client, corpus_engagement_provid
 
 @pytest.fixture
 def for_you_slate_pocket_home_v3_provider(corpus_feature_group_client, corpus_engagement_provider, translation_provider):
-    unleash_provider = MagicMock(UnleashProvider)
-    unleash_provider.get_assignment.return_value = UnleashAssignmentModel(assigned=True, name=POCKET_HOME_V4_FEATURE_FLAG)
     return ForYouSlateProvider(
         corpus_fetchable=corpus_feature_group_client,
         corpus_engagement_provider=corpus_engagement_provider,
         recommendation_surface_id=RecommendationSurfaceId.HOME,
         locale=LocaleModel.en_US,
         translation_provider=translation_provider,
-        unleash_provider=unleash_provider
     )
 
 @pytest.mark.asyncio

--- a/tests/unit/data_providers/test_home_dispatch.py
+++ b/tests/unit/data_providers/test_home_dispatch.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from app.config import POCKET_HOME_V4_FEATURE_FLAG
 from app.data_providers.corpus.corpus_feature_group_client import CorpusFeatureGroupClient
 from app.data_providers.dispatch import HomeDispatch
 from app.data_providers.slate_providers.collection_slate_provider import CollectionSlateProvider
@@ -84,6 +83,7 @@ class TestHomeDispatch:
         Test that corpus recommendations are deduplicated across slates in the Home lineup.
         """
         self.preferences_provider.fetch.return_value = None
+        self.unleash_provider.get_assignment.return_value = None
         self.home_dispatch.collection_slate_provider.get_slate.return_value = _generate_slate(
             ['Coll1', 'Coll2', 'Coll3'], headline='Collections')
         self.home_dispatch.pocket_worthy_provider.get_slate.return_value = _generate_slate(


### PR DESCRIPTION
# Goal

Testing with an a/b test if/and how removing the syndication slate affects engagement

Flag: https://featureflags.readitlater.com/projects/default/features/temp.recommendation-api.pocket-home-no-syndication