### PR TITLE
fix(locales): updating the config to use the english ids for mapping

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -124,3 +124,4 @@ ES_ES_HOME_TOPICS = [
 
 # Changes the slate lineups for home and removes syndication as a a/b test
 POCKET_HOME_NO_SYNDICATION_FEATURE_FLAG = 'temp.recommendation-api.pocket-home-no-syndication'
+POCKET_HOME_MORE_LOCALES = 'temp.recommendation-api.home.more-locales'

--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,10 @@ qa_slate_map = {
 # For running Open Telemetry locally, set `OTEL_DAEMON_ADDRESS`, otherwise defaults to production value.
 otel_daemon_address = os.getenv('OTEL_DAEMON_ADDRESS', 'http://127.0.0.1:4317')
 
+# Note: All the topics here use the English version of the Candidate Set Ids.
+# They then get merged with the metadata from DynamoDB, TopicMetadata table and our translation files in this repository.
+# From there it is then mapped to the real candidate set id for that language from the _TOPIC_CANDIDATE_SETS variable based on the locale model
+
 DEFAULT_TOPICS = [
     '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
     'c6242e35-4ef7-494f-ae9f-51f95b836424',  # Entertainment
@@ -91,31 +95,31 @@ GERMAN_HOME_TOPICS = [
 
 
 EN_GB_HOME_TOPICS = [
-    'b0d0c28b-a2b4-4142-ac5b-8f2ac69766eb',  # Technology
-    'f24c8da6-11d1-40de-9bf7-27dfde0bed9f',  # Business
-    '963d5c09-052a-4649-8d36-097766de068f',  # Science
-    '5d8e5764-77d7-4686-887e-84aaddcf482c',  # Self-improvement
+    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
+    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
+    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
+    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
 ]
 
 FR_FR_HOME_TOPICS = [
-    '19a95471-02b4-4133-81e6-21a7e66b247d',  # Technology
-    'd2a31a31-3498-4f0a-8ca3-fbd29ed7c6c2',  # Business
-    'c8e5f613-161f-411b-bb13-b3a590cae80c',  # Science
-    'd77168b1-68a9-4942-91ea-bed18defca02',  # Self-improvement
+    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
+    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
+    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
+    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
 ]
 
 IT_IT_HOME_TOPICS = [
-    '052eb916-b15e-480e-b9f8-b06bc8070b15',  # Technology
-    'ce8b6f8e-e5cc-4c1f-a280-32556a6ab902',  # Business
-    'dbc6fbd2-6c2e-4bb2-98f5-fccc3b05835a',  # Science
-    'a91654c2-b78d-4377-90ea-4f1252ff60c9',  # Self-improvement
+    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
+    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
+    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
+    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
 ]
 
 ES_ES_HOME_TOPICS = [
-    '177d3d8d-7733-402d-bf76-39eb9c2e24cd',  # Technology
-    'e6e1696e-571a-49a6-ac27-1de508fc1f31',  # Business
-    'bd983eba-0b4a-4916-82dd-d3a212ce934b',  # Science
-    'b3c241b0-3651-4460-977c-568cbfbef2c3',  # Self-improvement
+    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
+    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
+    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
+    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
 ]
 
 # Changes the slate lineups for home and removes syndication as a a/b test

--- a/app/config.py
+++ b/app/config.py
@@ -75,51 +75,12 @@ qa_slate_map = {
 # For running Open Telemetry locally, set `OTEL_DAEMON_ADDRESS`, otherwise defaults to production value.
 otel_daemon_address = os.getenv('OTEL_DAEMON_ADDRESS', 'http://127.0.0.1:4317')
 
-# Note: All the topics here use the English version of the Candidate Set Ids.
-# They then get merged with the metadata from DynamoDB, TopicMetadata table and our translation files in this repository.
-# From there it is then mapped to the real candidate set id for that language from the _TOPIC_CANDIDATE_SETS variable based on the locale model
-
-DEFAULT_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    'c6242e35-4ef7-494f-ae9f-51f95b836424',  # Entertainment
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
-]
-
 # German Home shows different topics by default
-GERMAN_HOME_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
-    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
-]
-
-
-EN_GB_HOME_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
-    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
-]
-
-FR_FR_HOME_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
-    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
-]
-
-IT_IT_HOME_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
-    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
-]
-
-ES_ES_HOME_TOPICS = [
-    '25c716f1-e1b2-43db-bf52-1a5553d9fb74',  # Technology
-    '1bf756c0-632f-49e8-9cce-324f38f4cc71',  # Business
-    '058011b8-c70d-4a25-92e5-478e3ff0f0e6',  # Science
-    '45f8e740-42e0-4f54-8363-21310a084f1f',  # Self-improvement
+NON_EN_US_HOME_TOPICS = [
+    'TECHNOLOGY',
+    'BUSINESS',
+    'SCIENCE',
+    'SELF_IMPROVEMENT',
 ]
 
 # Changes the slate lineups for home and removes syndication as a a/b test

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -233,7 +233,7 @@ class HomeDispatch:
             self.life_hacks_slate_provider.get_slate(enable_thompson_sampling_with_seed=seed_id,
                                                      user_impression_capped_list=user_impression_capped_list),
         ]
-        if no_syndication_assignment is not None and no_syndication_assignment.variant == 'treatment' is True:
+        if no_syndication_assignment is not None and no_syndication_assignment.variant == 'treatment':
             del slates[0]
 
         return CorpusSlateLineupModel(

--- a/app/data_providers/slate_providers/collection_slate_provider.py
+++ b/app/data_providers/slate_providers/collection_slate_provider.py
@@ -11,12 +11,11 @@ class CollectionSlateProvider(HomeSlateProvider):
 
     @property
     def candidate_set_id(self) -> str:
-        if self.locale == LocaleModel.en_US:
-            return '92af3dae-25c9-46c3-bf05-18082aacc7e1'
-        elif self.locale == LocaleModel.de_DE:
+        if self.locale == LocaleModel.de_DE:
             return 'ce0e010b-d73d-45e2-a4cd-4abbff74d168'
         else:
-            raise ValueError(f'Unexpected locale {self.locale} for {self.provider_name}')
+            # Default to en-US for the rest of the world
+            return '92af3dae-25c9-46c3-bf05-18082aacc7e1'
 
     @property
     def more_link(self) -> Optional[LinkModel]:

--- a/app/data_providers/snowplow/snowplow_corpus_recommendations_tracker.py
+++ b/app/data_providers/snowplow/snowplow_corpus_recommendations_tracker.py
@@ -78,12 +78,16 @@ class SnowplowCorpusRecommendationsTracker:
         :param user: The user that the slate was recommended to.
         :param api_client: The client that originated the request.
         """
+        context = [
+            get_feature_flag_entity(assignment),
+        ]
+        if user:
+            context.append(get_user_entity(user))
+
+        if api_client:
+            context.append(get_api_user_entity(api_client))
         await self.tracker.track_self_describing_event(
             event_json=get_variant_enroll_event(),
             event_subject=get_subject(user) if user else None,
-            context=[
-                get_feature_flag_entity(assignment),
-                get_user_entity(user),
-                get_api_user_entity(api_client),
-            ],
+            context=context,
         )

--- a/app/data_providers/topic_provider.py
+++ b/app/data_providers/topic_provider.py
@@ -42,11 +42,20 @@ class TopicProvider:
             response = await table.scan()
             return response['Items']
 
-    async def get_topics(self, topics_ids: Sequence[str]) -> List[TopicModel]:
+    async def get_topics_by_legacy_id(self, topics_ids: Sequence[str]) -> List[TopicModel]:
         """
-        :param topics_ids: List or tuple of topic ids. Invalid ids are ignored.
+        :param topics_ids: List or tuple of legacy UUID topic ids. Invalid ids are ignored.
         :return: A list of TopicModel objects for the given topic_ids.
         """
         all_topics = await self.get_all()
         topics_by_id = {topic.id: topic for topic in all_topics}
+        return [topics_by_id[topic_id] for topic_id in topics_ids if topic_id in topics_by_id]
+
+    async def get_topics_by_corpus_topic_id(self, topics_ids: Sequence[str]) -> List[TopicModel]:
+        """
+        :param topics_ids: List or tuple of corpus topic ids. Invalid ids are ignored.
+        :return: A list of TopicModel objects for the given topic_ids.
+        """
+        all_topics = await self.get_all()
+        topics_by_id = {topic.corpus_topic_id: topic for topic in all_topics}
         return [topics_by_id[topic_id] for topic_id in topics_ids if topic_id in topics_by_id]

--- a/app/data_providers/translation.py
+++ b/app/data_providers/translation.py
@@ -17,5 +17,16 @@ class TranslationProvider:
         :param filename: Filename (e.g. home.json)
         :return: Dict mapping translation keys to translated strings
         """
-        with open(path.join(self.translations_dir, locale.value, filename), 'r') as fp:
-            return json.load(fp)
+
+
+        # Load the en-US file as our fallback
+        with open(path.join(self.translations_dir, 'en-US', filename), 'r') as fallback_file:
+            fallback_data = json.load(fallback_file)
+
+        # Load the file for our translations
+        with open(path.join(self.translations_dir, locale.value, filename), 'r') as translated_file:
+            translated_data = json.load(translated_file)
+
+        # Merge the two dictionaries
+        # If there are overlapping keys, translated_data will override fallback_data
+        return {**fallback_data, **translated_data}

--- a/app/data_providers/user_recommendation_preferences_provider.py
+++ b/app/data_providers/user_recommendation_preferences_provider.py
@@ -92,7 +92,7 @@ class UserRecommendationPreferencesProvider:
         return UserRecommendationPreferencesModel(
             hashed_user_id=record[self._FEATURE_ID_NAME],
             updated_at=dateutil.parser.isoparse(record['updated_at']),
-            preferred_topics=await self.topic_provider.get_topics([t['id'] for t in preferred_topics])
+            preferred_topics=await self.topic_provider.get_topics_by_legacy_id([t['id'] for t in preferred_topics])
         )
 
     @classmethod

--- a/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
+++ b/app/graphql/resolvers/user_recommendation_preferences_resolvers.py
@@ -27,7 +27,7 @@ async def update_user_recommendation_preferences(
         topic_provider=topic_provider
     )
 
-    preferred_topics = await topic_provider.get_topics([t.id for t in input.preferred_topics])
+    preferred_topics = await topic_provider.get_topics_by_legacy_id([t.id for t in input.preferred_topics])
     request_user = get_request_user(info)
 
     model = UserRecommendationPreferencesModel(

--- a/app/models/topic.py
+++ b/app/models/topic.py
@@ -16,7 +16,7 @@ class TopicModel(BaseModel):
     """
     Models a topic, e.g. Technology, Gaming.
     """
-    id: str = Field(description='The id of the topic')
+    id: str = Field(description='The legacy UUID id of the topic')
     corpus_topic_id: str = Field(description='Corpus API topic identifier')
     name: str = Field(description='The name of the topic to show to the user')
     display_name: str = Field(description='The name of the topic to show to the user')


### PR DESCRIPTION
# Goal

It turns out when passing topic ids to the topic slate provider, you should be using the english ids, which then get merged with metadata from dynamodb, and our translations and then re-mapped into their real candidate set ids from the _TOPIC_CANDIDATE_SETS variables


I tested this locally against Prod.


This also puts all the extra locales behind an experiment feature flag.