### PR TITLE
fix(enrollment): updating enrollment to always send for locales

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -84,4 +84,4 @@ NON_EN_US_HOME_TOPICS = [
 
 # Changes the slate lineups for home and removes syndication as a a/b test
 POCKET_HOME_NO_SYNDICATION_FEATURE_FLAG = 'temp.recommendation-api.pocket-home-no-syndication'
-POCKET_HOME_MORE_LOCALES = 'temp.recommendation-api.home.more-locales'
+POCKET_HOME_MORE_LOCALES = 'temp.recommendation-api.home.more-locales-v2'

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -182,7 +182,10 @@ class HomeDispatch:
             slate_lineup_model, experiment = await self.get_en_us_slate_lineup(
                 recommendation_count=recommendation_count, user=user)
 
-        if more_locales_assignment is not None and experiment is None:
+        # If we are in our custom locale group, and the flag is turned on, and we are assigned it. (control or treatement)
+        # Then we need to emit an enrollment
+        if (locale in (LocaleModel.en_GB, LocaleModel.fr_FR, LocaleModel.it_IT, LocaleModel.es_ES)
+              and more_locales_assignment is not None and more_locales_assignment.assigned == True):
             asyncio.create_task(
                 self.snowplow.track(CorpusRecommendationsSendEvent(
                     corpus_slate_lineup=slate_lineup_model,
@@ -192,7 +195,9 @@ class HomeDispatch:
                     api_client=api_client,
                     experiment=more_locales_assignment
                 )))
-        else:
+
+        ## No matter what, if we have an experiment from the slate lineup, we need to emit an enrollment of it.
+        if experiment is not None:
             asyncio.create_task(
                 self.snowplow.track(CorpusRecommendationsSendEvent(
                     corpus_slate_lineup=slate_lineup_model,

--- a/app/data_providers/dispatch.py
+++ b/app/data_providers/dispatch.py
@@ -195,9 +195,7 @@ class HomeDispatch:
                     api_client=api_client,
                     experiment=more_locales_assignment
                 )))
-
-        ## No matter what, if we have an experiment from the slate lineup, we need to emit an enrollment of it.
-        if experiment is not None:
+        else:
             asyncio.create_task(
                 self.snowplow.track(CorpusRecommendationsSendEvent(
                     corpus_slate_lineup=slate_lineup_model,

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -148,7 +148,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
+            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -184,7 +184,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
+            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -220,7 +220,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
+            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -263,4 +263,4 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
+            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}

--- a/tests/functional/graphql/test_home_slate_lineup.py
+++ b/tests/functional/graphql/test_home_slate_lineup.py
@@ -148,7 +148,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -184,7 +184,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -220,7 +220,7 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}
 
     @patch.object(CorpusFeatureGroupClient, 'fetch')
     @patch.object(UserRecommendationPreferencesProvider, 'fetch')
@@ -263,4 +263,4 @@ class TestHomeSlateLineup(TestDynamoDBBase):
 
             await wait_for_snowplow_events(self.snowplow_micro, n_expected_event=2)
             all_snowplow_events = self.snowplow_micro.get_event_counts()
-            assert all_snowplow_events == {'total': 0, 'good': 0, 'bad': 0}
+            assert all_snowplow_events == {'total': 1, 'good': 1, 'bad': 0}


### PR DESCRIPTION
# Goal

The feature flag enrollment had a bug where we were not emitting enrollment events for those that were in the control group.


This makes the logic so that if the user is in one of the locale groups, and they are in the flag, we will emit an enrollment event.