### PR TITLE
fix: upgrade remote docker image to 20.10.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
         default: '/tmp/workspace'
       remote-docker-version:
         type: string
-        default: '20.10.18'
+        default: '20.10.24'
         description: 'Specific remote docker version'
       remote-docker-layer-caching:
         type: boolean


### PR DESCRIPTION
# Goal
Fix deployment issue:

> This job was rejected because the image 'Remote Docker version: docker-20.10.18' is [unavailable](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/)

[CircleCI Docker lifespan documentation](https://circleci.com/docs/remote-docker-images-support-policy/) says:

> We will support one version of Docker 20 with a tag of 20.10.24

## Todos
- [ ] Test in dev

## Reference

Tickets:
* [MC-1550](https://mozilla-hub.atlassian.net/browse/MC-1550)



[MC-1550]: https://mozilla-hub.atlassian.net/browse/MC-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ