### PR TITLE
fix: Upgrade remote Docker image to docker24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,6 @@ jobs:
                 build_path: << parameters.path >>
                 tag: << parameters.tag >>
                 extra_build_args: << parameters.extra-build-args >>
-                platform: 'linux/amd64,linux/arm64'
                 region: "${<< parameters.aws-region >>}"
       - unless:
           condition: << parameters.push >>
@@ -169,7 +168,6 @@ jobs:
                 build_path: << parameters.path >>
                 tag: << parameters.tag >>
                 extra_build_args: << parameters.extra-build-args >>
-                platform: 'linux/amd64,linux/arm64'
                 region: "${<< parameters.aws-region >>}"
                 push_image: false
 


### PR DESCRIPTION
# Goal

Revert the remote Docker version back to docker24, which it was at until I accidentally downgraded it in https://github.com/Pocket/recommendation-api/pull/1102.