### PR TITLE
(chore): MC-511: upgrade lambda python

### DIFF
--- a/.aws/src/monitoring.ts
+++ b/.aws/src/monitoring.ts
@@ -167,7 +167,7 @@ export class RecommendationApiSynthetics extends Construct {
               'RECOMMENDATION_API_DOMAIN': config.domain,
           }
         },
-        runtimeVersion: 'syn-python-selenium-1.3',
+        runtimeVersion: 'syn-python-selenium-4.1',
         schedule: {
           expression: 'rate(5 minutes)', // run every 5 minutes
         },

--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -30,7 +30,7 @@ export class SqsLambda extends Construct {
         visibilityTimeoutSeconds: 300,
       },
       lambda: {
-        runtime: 'python3.12' as LAMBDA_RUNTIMES,
+        runtime: 'python3.11' as LAMBDA_RUNTIMES,
         handler: 'aws_lambda.sqs_handler.handler',
         timeout: 120,
         executionPolicyStatements: [

--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -30,7 +30,7 @@ export class SqsLambda extends Construct {
         visibilityTimeoutSeconds: 300,
       },
       lambda: {
-        runtime: LAMBDA_RUNTIMES.PYTHON38,
+        runtime: 'python3.12' as LAMBDA_RUNTIMES,
         handler: 'aws_lambda.sqs_handler.handler',
         timeout: 120,
         executionPolicyStatements: [

--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -30,7 +30,7 @@ export class SqsLambda extends Construct {
         visibilityTimeoutSeconds: 300,
       },
       lambda: {
-        runtime: 'python3.11' as LAMBDA_RUNTIMES,
+        runtime: 'python3.9' as LAMBDA_RUNTIMES,
         handler: 'aws_lambda.sqs_handler.handler',
         timeout: 120,
         executionPolicyStatements: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
         default: "aws_lambda/"
         type: string
     docker:
-      - image: python:3.8
+      - image: python:3.12
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -179,7 +179,7 @@ jobs:
         type: boolean
         default: true
     docker:
-      - image: python:3.8
+      - image: python:3.12
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
         default: "aws_lambda/"
         type: string
     docker:
-      - image: python:3.11
+      - image: python:3.9
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -179,7 +179,7 @@ jobs:
         type: boolean
         default: true
     docker:
-      - image: python:3.11
+      - image: python:3.9
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
         default: "aws_lambda/"
         type: string
     docker:
-      - image: python:3.12
+      - image: python:3.11
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -179,7 +179,7 @@ jobs:
         type: boolean
         default: true
     docker:
-      - image: python:3.12
+      - image: python:3.11
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/aws_lambda/Pipfile
+++ b/aws_lambda/Pipfile
@@ -19,4 +19,4 @@ boto3-stubs = {extras = ["essential"], version = "*"}
 sentry-sdk = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.12"

--- a/aws_lambda/Pipfile
+++ b/aws_lambda/Pipfile
@@ -19,4 +19,4 @@ boto3-stubs = {extras = ["essential"], version = "*"}
 sentry-sdk = "*"
 
 [requires]
-python_version = "3.12"
+python_version = "3.11"

--- a/aws_lambda/Pipfile
+++ b/aws_lambda/Pipfile
@@ -19,4 +19,4 @@ boto3-stubs = {extras = ["essential"], version = "*"}
 sentry-sdk = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.9"

--- a/aws_lambda/tests/test_sqs_lambda.py
+++ b/aws_lambda/tests/test_sqs_lambda.py
@@ -7,7 +7,7 @@ import time
 import pytest
 from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 import boto3
-from moto import mock_dynamodb2
+from moto import mock_aws
 
 from aws_lambda.tests.fixtures.lambda_sqs_event import event, body, body2
 from aws_lambda.tests.fixtures.lambda_sqs_event_without_id import event_without_id
@@ -20,7 +20,7 @@ DYNAMODB_LOCALSTACK_DIR = os.path.join(ROOT_DIR, '.docker/localstack/dynamodb/')
 
 @pytest.fixture(scope='function')
 def mock_dynamodb_resource():
-    with mock_dynamodb2():
+    with mock_aws():
         yield boto3.resource('dynamodb')
 
 


### PR DESCRIPTION
# Goal

Python 3.8 has been deprecated starting October 14.Upgrading the Python version to Python3.9 for the following lambda functions:

* `RecommendationAPI-Prod-SQS-Translation`
* `cwsyn-recapi`

Decided not to upgrade to the most recent pocket tf modules (v5) as this introduced a lot of breaking changes, so referencing `python3.9` lambda runtime directly. According to [AWS](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), there is no scheduled date to deprecate this version (as of now). 

`python3.9` seems to be the best version to use for now. Tried upgrading first to `Python3.12`, but there [has been an issue during build](https://stackoverflow.com/questions/77274572/multiqc-modulenotfounderror-no-module-named-imp). Upgrading to `python3.10` & `python3.11` also was problematic due to `cdktf` [dependency issues ](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/410318598490/projects/RecommendationAPI-Dev/build/RecommendationAPI-Dev%3Adbed8f2f-3766-45dc-920b-378115add03b/?region=us-east-1). 

## Todos
- [x] deployed to dev

## Reference

Tickets:
* https://mozilla-hub.atlassian.net/browse/MC-1511
